### PR TITLE
Use highlight tag instead of three backticks or tildes for code blocks

### DIFF
--- a/app/_posts/2019-07-09-teaching-data-science-for-lawyers-with-caselaw-access-project-data.md
+++ b/app/_posts/2019-07-09-teaching-data-science-for-lawyers-with-caselaw-access-project-data.md
@@ -65,7 +65,7 @@ C.  A Python `list` of unique U.S. Supreme Court citations that appear in the te
 
 ### Sample Code to Complete Assignment
 
-```python
+{% highlight python %}
 import requests, re
 endpoint = "https://api.case.law/v1/cases/"
 pattern = r"\d+ U\.S\. \d+"
@@ -90,4 +90,4 @@ def cite_finder(cite):
         filtered.sort()
         return filtered
     return None
-```
+{% endhighlight %}

--- a/app/assets/css/blog.scss
+++ b/app/assets/css/blog.scss
@@ -260,10 +260,10 @@
   }
 }
 
-.highlighter-rouge, .highlighter-rouge * {
+figure.highlight pre {
   overflow: scroll;
 }
-.highlight {
+figure.highlight {
   // via http://help.farbox.com/pygments.html
   background: #f8f8f8;
   .hll { background-color: #ffffcc }


### PR DESCRIPTION
This is a little unfortunate, in that it doesn't allow us to use backticks or tildes for fenced code blocks with syntax highlighting; however, it's the only way I've found so far to make the output look clean and scroll. See the code block at the end of https://lil.law.harvard.edu/blog/2019/07/09/teaching-data-science-for-lawyers-with-caselaw-access-project-data/ for an example. This PR changes that post, as well as one earlier one; there may be a couple of earlier posts that need attention.