### PR TITLE
First cut at validating title in YAML frontmatter

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
-set -ev
+validate_frontmatter () {
+    grep -r '^title: ' app | while read MATCH
+    do
+        FILE=`echo $MATCH | cut -f 1 -d ':'`
+        TITLE=`echo $MATCH | cut -f 2- -d ':' | sed 's/^title: //'`
+        if echo $TITLE | grep ':' | grep -q -v [\'\"]
+        then
+            echo "Invalid YAML: $FILE needs title quoted"
+            return 1
+        fi
+    done
+}
 
-docker-compose run jekyll jekyll build
-java -jar node_modules/vnu-jar/build/dist/vnu.jar --skip-non-html --errors-only --filterfile tests/config/vnufilter.txt build/
+if validate_frontmatter
+then
+    docker-compose run jekyll jekyll build
+    java -jar node_modules/vnu-jar/build/dist/vnu.jar --skip-non-html --errors-only --filterfile tests/config/vnufilter.txt build/
+else
+    exit 1
+fi


### PR DESCRIPTION
This is a second attempt to fail builds when there's a problem in the YAML frontmatter of a post, specifically a colon in a title that is not wrapped in quotation marks. See #234 for the first attempt, and some links to Jekyll issues -- Jekyll's position is that these problems should not cause the build to fail.

This will fail on the first such problem, which is not perfect -- it won't report problems in multiple files -- but is probably fine in practice, where a PR generally consists of a single blog post.

There's probably a slicker way to accomplish the validation than this bash function. Say, an actual YAML validator, maybe the one that Jekyll is using?

It's probably worth checking frontmatter elements other than title.