### PR TITLE
Another swing at alt text for figures

### DIFF
--- a/app/_posts/2019-09-17-nelson-guest.md
+++ b/app/_posts/2019-09-17-nelson-guest.md
@@ -15,23 +15,26 @@ The resulting dataset contains 1,702,404 cases from 77 courts of last resort. Th
 
 To examine citation practices in state supreme courts, we first needed to extract citations from each state supreme court opinion. For this purpose, we utilize the LexNLP Python package released by [LexPredict](https://www.lexpredict.com/), a data-driven consulting and technology firm. In addition to parsing the citation (i.e. 1 Ill. 19), we also extract the report the opinion is published in and the court of the case cited (i.e. Illinois Supreme Court). Most state supreme court cases--- about 68.7% of majority opinions greater than 100 words---cite another case. About one-third of cases cite between 1 and 5 other cases while about 5% of cases cite 25 or more other cases. The number of citations in an opinion trends upward with time, as Figure 1 shows. 
 
-![Figure 1](https://lil-blog-media.s3.amazonaws.com/Picture1.png)
-
-### Figure 1: The average number of citations in a state supreme court opinion since the American founding. 
+<figure>
+    <img src="https://lil-blog-media.s3.amazonaws.com/Picture1.png" alt="plot of the average number of citations between the late 1700s and early 2000s, increasing exponentially from about 0 to about 15">
+    <figcaption>Figure 1: The average number of citations in a state supreme court opinion since the American founding.</figcaption>
+</figure>
 
 The number of citations in a case varies by state, as well. Some state courts tend to write opinions with a greater number of citations than other state courts. Figure 2 presents the proportion of opinions (with at least 100 words) in each state with at least three citations since 1950. States like Florida, New York, Louisiana, Oregon, and Michigan produce the greatest proportion of opinions with less than three citations. It may not be coincidence that Louisiana and New York are two of the highest caseload state courts in the country; judges with many cases on their dockets may be forced to publish opinions more quickly with less research and legal writing allocated to citing precedent. Conversely, cases with low caseloads like Montana and Wyoming produce the greatest proportion of cases with at least three citations. When judges have more time to craft an opinion, they produce opinions that are more well-grounded in existing precedent.
 
-![Figure 2](https://lil-blog-media.s3.amazonaws.com/Picture2.png)
-
-### Figure 2: The proportion of state supreme court opinions citing at least three cases by state since 1950 (the two Texas and Oklahoma high courts are aggregated).
+<figure>
+    <img src="https://lil-blog-media.s3.amazonaws.com/Picture2.png" alt="choropleth map of the United States">
+    <figcaption>Figure 2: The proportion of state supreme court opinions citing at least three cases by state since 1950 (the two Texas and Oklahoma high courts are aggregated).</figcaption>
+</figure>
 
 
 ## Explaining Differences in State Supreme Court Citation
 We expected that the number of citations included in a state supreme court method would vary based on the method through which a state supreme court’s justices are retained. We use linear regression to model the median number of citations in a state-year as a function of selection method, caseload, partisan control of the state legislature, and general state expenditures. We restrict the time period for this analysis to the 1942-2010 period.
 
-![Figure 3](https://lil-blog-media.s3.amazonaws.com/Picture3.png)
-
-### Figure 3: Linear Regression results of the effects of judicial retention method on the average number of citations in a state supreme court opinion, including state and year fixed effects.
+<figure>
+    <img src="https://lil-blog-media.s3.amazonaws.com/Picture3.png" alt="regression results with confidence intervals and coefficient estimates">
+    <figcaption>Figure 3: Linear Regression results of the effects of judicial retention method on the average number of citations in a state supreme court opinion, including state and year fixed effects.</figcaption>
+</figure>
 
 The results are shown in Figure 3. Compared to judges who face nonpartisan elections, judges who are appointed, face retention elections, and face partisan elections include more citations in their opinions. In appointed systems, the median opinion contains about 3 more citations (about three-fifths of a standard deviation shift) than in nonpartisan election systems. In retention election systems, the median opinion contains almost 5 more citations (about a full standard deviation shift in citations) than in nonpartisan election systems. Even in partisan election systems, the median opinion contains a little less than 3 more citations. 
 


### PR DESCRIPTION
These alt texts may not be awesome, but they're the best I could come up with. The text of the article summarizes the figure contents, and we don't want to duplicate the captions, so it's a little tough. It would be nice if we could link to the data, so that it could be explored non-visually, but I don't think the data is on the web presently.