### PR TITLE
Change internal headings from h1 to h3

### DIFF
--- a/app/_posts/2020-02-27-caselaw-access-project-downloads-now-available.md
+++ b/app/_posts/2020-02-27-caselaw-access-project-downloads-now-available.md
@@ -4,17 +4,17 @@ author: kelly-fitzpatrick
 ---
 Today we're announcing [CAP downloads](https://case.law/download/), a new way to access select datasets relating to the [Caselaw Access Project](https://case.law/). While researchers can use our [API](https://api.case.law) and [bulk data](https://case.law/bulk/download) to access standardized metadata and text for all of the cases in the CAP dataset, we also want to make it possible to share specialized and derivative datasets.
 
-# How does it work?
+### How does it work?
 
 Everything available for download is presented in a simple file directory that lets you navigate to the specific dataset or file you want. Each dataset or export comes with a README file that includes basic information about it.
 
-# What data do we have?
+### What data do we have?
 
 To view and access what's currently available, visit [case.law/download](https://case.law/download). We're starting with:
 - Scanned images of cases from open access jurisdictions (AR, IL, NC, NM), available as PDFs: [case.law/download/PDFs/](https://case.law/download/PDFs/)
 - A spreadsheet mapping metadata in CAP to metadata from the [Supreme Court Database (SCDB)](http://scdb.wustl.edu/): [case.law/download/scdb/](https://case.law/download/scdb/)
 - Images and illustrations found in published case law: [case.law/download/illustrations/](https://case.law/download/illustrations/)
 
-# What other datasets should we share?
+### What other datasets should we share?
 
 If you have ideas or suggestions for other datasets you'd like us to share, we'd love to hear about it. Contact us at [case.law/contact/](https://case.law/contact/)!


### PR DESCRIPTION
Headings inside a blog post should start with `###`, making them `h3`, since the blog post title itself is an `h2`.