### PR TITLE
Add charset=utf-8 to Content-Type to fix JSON output

### DIFF
--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -504,6 +504,7 @@ LogLevel warn
 
 <VirtualHost *:8080>
     DocumentRoot "/usr/local/apache2/htdocs"
+    AddCharset UTF-8 .js
 </VirtualHost>
 
 

--- a/apache/httpd.conf
+++ b/apache/httpd.conf
@@ -504,7 +504,6 @@ LogLevel warn
 
 <VirtualHost *:8080>
     DocumentRoot "/usr/local/apache2/htdocs"
-    AddCharset UTF-8 .js
 </VirtualHost>
 
 

--- a/app/.htaccess
+++ b/app/.htaccess
@@ -2,6 +2,8 @@
 ---
 DirectoryIndex  index.html index.js index.xml index.php
 
+AddCharset UTF-8 .js
+
 ErrorDocument 404 /404/index.html
 
 # compress text, html, javascript, css, xml:


### PR DESCRIPTION
Before, `/api/news/perma-cc/` included `"title":"Death to â€œLink Rotâ€: Here's Where the Internet Goes to Live Forever"`; with this change, we get `"title":"Death to “Link Rot”: Here's Where the Internet Goes to Live Forever"`.

This fix is temporary in that we are moving in production from Apache to Nginx, so will need to overhaul the web server in our development environment.