### PR TITLE
Sharing images only work with absolute URLs.

### DIFF
--- a/app/_includes/sharing-image.html
+++ b/app/_includes/sharing-image.html
@@ -20,11 +20,11 @@
 
 <meta name="twitter:card" content="{{ page.sharing-card-type }}">
 <meta name="twitter:site" content="@{{ site.twitter_account_name }}">
-<meta name="twitter:image" content="{{ site.baseurl }}/assets/{{ sharing-image | strip }}">
+<meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}/assets/{{ sharing-image | strip }}">
 
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ site.url }}{{ site.baseurl }}{{ page.url | replace:'index.html',''}}">
-<meta property="og:image" content="{{ site.baseurl }}/assets/{{ sharing-image | strip }}">
+<meta property="og:image" content="{{ site.url }}{{ site.baseurl }}/assets/{{ sharing-image | strip }}">
 
 {% if sharing-description %}
   <meta name="twitter:description" content="{{ sharing-description | strip }}">


### PR DESCRIPTION
With this change the local previews don't work without intervention... but that's okay, the local previews are pretty lousy in the best case anyway.