### PR TITLE
Add a cache-busting querystring for CSS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
                     git config user.email "lil@law.harvard.edu"
                     git config user.name "Circle CI"
                     git add app/_layouts/default.html app/_includes/custom-css.html
-                    git commit -m 'Increment CSS cache-buster[skip ci]'
+                    git commit -m 'Increment CSS cache-buster [skip ci]'
                     git push origin develop || exit 1
                 fi
                 export DEPLOY_CONTENT='{"CIRCLE_BUILD_NUM":"'$CIRCLE_BUILD_NUM'","CIRCLE_SHA1":"'$CIRCLE_SHA1'","CIRCLE_BRANCH":"'$CIRCLE_BRANCH'","CIRCLE_PROJECT_REPONAME":"'$CIRCLE_PROJECT_REPONAME'","CIRCLE_PROJECT_USERNAME":"'$CIRCLE_PROJECT_USERNAME'"}' ;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,18 @@ jobs:
           name: "Deploy"
           command: |
             if [[ "$CIRCLE_PULL_REQUEST" == "" && "$CIRCLE_BRANCH" == "develop" ]] ; then
+                CSS_BUST=$(find build/assets/css -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://lil.law.harvard.edu/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
+                if [[ $CSS_BUST ]] ; then
+                    COUNTER=`grep cache-buster app/_layouts/default.html | sed -r 's/.*cache-buster=([0-9]+).*/\1/'`
+                    let NEWCOUNTER=$COUNTER+1
+                    perl -pi -e "s/cache-buster=$COUNTER/cache-buster=$NEWCOUNTER/" app/_layouts/default.html
+                    perl -pi -e "s/cache-buster=$COUNTER/cache-buster=$NEWCOUNTER/" app/_includes/custom-css.html
+                    git config user.email "lil@law.harvard.edu"
+                    git config user.name "Circle CI"
+                    git add app/_layouts/default.html app/_includes/custom-css.html
+                    git commit -m 'Increment CSS cache-buster[skip ci]'
+                    git push origin develop || exit 1
+                fi
                 export DEPLOY_CONTENT='{"CIRCLE_BUILD_NUM":"'$CIRCLE_BUILD_NUM'","CIRCLE_SHA1":"'$CIRCLE_SHA1'","CIRCLE_BRANCH":"'$CIRCLE_BRANCH'","CIRCLE_PROJECT_REPONAME":"'$CIRCLE_PROJECT_REPONAME'","CIRCLE_PROJECT_USERNAME":"'$CIRCLE_PROJECT_USERNAME'"}' ;
                 export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;
                 curl -X POST "$DEPLOY_URL" --data "$DEPLOY_CONTENT" -H "Content-Type: application/json" -H "X-Circle-Signature: $DEPLOY_SIG" ;

--- a/app/_includes/custom-css.html
+++ b/app/_includes/custom-css.html
@@ -1,10 +1,10 @@
 {% if layout.custom-css %}
   {% for file in layout.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?cache-buster=1">
   {% endfor %}
 {% endif %}
 {% if page.custom-css %}
   {% for file in page.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?cache-buster=1">
   {% endfor %}
 {% endif %}

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -10,7 +10,7 @@
     <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url | replace:'index.html',''}}">
     <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/assets/images/favicon.png">
     <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/images/apple-touch-icon.png">
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?cache-buster=1">
     {% include custom-css.html %}
   </head>
   {{ content }}


### PR DESCRIPTION
... and increment in CI if built CSS differs from live.

Will this work? I think so.....

I based it on H2O's code that [adds the built JS to the repo](https://github.com/harvard-lil/h2o/blob/develop/.circleci/config.yml#L93-L99).

`CSS_BUST` gets populated when a file in the build assets directory differs from its equivalent on the live site. It works fine for new files that are absent on the deployed site too:
```
rcremona@HLSNHJGWY2X2J website-static % touch build/assets/css/new.css
rcremona@HLSNHJGWY2X2J website-static % CSS_BUST=$(find build/assets/css -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://lil.law.harvard.edu/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
rcremona@HLSNHJGWY2X2J website-static % echo $CSS_BUST
bust (build/assets/css/new.css)
```
If `CSS_BUST` is populated, we increment the `cache-buster=[\d+]` in the layout files, using the same strategy as [Perma's script for updating Chrome](https://github.com/harvard-lil/perma/blob/develop/update_chrome.sh#L13-L18)

Then, we commit those two files, but tell CircleCI not to run again, so we don't get stuck in a loop.

Then, we continue with the deployment as usual... which as I understand from discussion, will build using the latest commit, the one we just added. If I'm wrong about that, then this will not workl!!!!

Those commands are a little intricate... No hard feelings if we feel like this is too fragile/risky and just want to close this LOL!!!! 
