### PR TITLE
Hide an easter egg, to test CSS cache-busting.

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -1536,3 +1536,19 @@ section.people-unaffiliated .list {
 .project footer { background-color: $color-highlight; }
 
 .about footer { background-color: $color-electricblue; }
+
+// Easter Egg
+.easter-egg {
+  text-align: center;
+  a {
+    color: $color-electricblue;
+  }
+  a:focus {
+    display: inline-block;
+    margin-bottom: 32px;
+    outline: 0;
+  }
+  span {
+    color: $color-black;
+  }
+}

--- a/app/index.html
+++ b/app/index.html
@@ -57,3 +57,5 @@ custom-scripts: ['jquery-3.1.1.min.js', 'home.js']
 
   </div>
 </section>
+
+<div class="easter-egg"><a href="https://www.youtube.com/watch?v=dQw4w9WgXcQ" class="sr-only sr-only-focusable"><span>You found</span> an item from our secret collection!</a></div>


### PR DESCRIPTION
Only discoverable by navigating with your keyboard at the bottom of the index page.

In general:
![image](https://user-images.githubusercontent.com/11020492/154577410-e67cf2f5-14dc-4efe-9957-ff456601f924.png)

On receiving keyboard focus:
![image](https://user-images.githubusercontent.com/11020492/154577471-79a9d44c-2aaf-426e-b3ff-772e8bf21c45.png)
