### PR TITLE
Add context to Technologist in Residence "apply" link

### DIFF
--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -147,7 +147,7 @@ sharing-description: "Now hiring developers!"
 
 				<h3>Apply</h3>
 				<p>
-					<a href="https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25240&siteid=5341&PageType=JobDetails&jobid=1943239">Technologist in Residence posting</a>
+					Our Technologist in Residence role is a one-year salaried position, so applications are accepted through the Harvard employment site: <a href="https://sjobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?partnerid=25240&siteid=5341&PageType=JobDetails&jobid=1943239">Technologist in Residence posting</a>. <strong>Please include a short cover letter explaining your interest and goals for the year.</strong>
 				</p>
 
 				<h3>Questions</h3>


### PR DESCRIPTION
Having "Technologist in Residence posting" be the link text strikes me as a little weird, but "apply here," "click to apply," and everything else I could think of to try looked even weirder, so just kept it. If anybody has a better idea, will change.

![image](https://user-images.githubusercontent.com/11020492/157504751-9c6a47c2-43bc-4481-8186-8efa0010290a.png)
