### PR TITLE
Use default for smart_quotes

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -2,8 +2,6 @@
 destination: ../build
 permalink: pretty
 markdown: kramdown
-kramdown:
-    smart_quotes: ["apos", "apos", "quot", "quot"]
 plugins:
   - jekyll-paginate-v2
   - jekyll-sitemap

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -8,7 +8,7 @@
              alt="Library Innovation Lab"
              class="img-full-width">
       </figure>
-      <h1 contenteditable="true">{{ page.title }}</h1>
+      <h1 contenteditable="true">{{ page.title | smartify }}</h1>
     </div>
     {% include nav.html %}
   </header>


### PR DESCRIPTION
This change will cause all quotation marks in regular text in the site to be rendered as curly aka smart quotes. I believe this will work whether the input source uses straight or curly quotes. Thanks to @lizadaly for the nudge to make this change.