### PR TITLE
Newsletter link in footer

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -20,6 +20,7 @@
   <li><a href="{{ site.baseurl }}/projects/">Projects</a></li>
   <li><a href="{{ site.baseurl }}/sketches/">Sketches</a></li>
   <li><a href="{{ site.baseurl }}/blog/">Blog</a></li>
+  <li><a href="https://ocb.to/lawvocado">Newsletter</a></li>
 </ul>
 <div class="footer-copyright">
   <p>&copy;2022 The President and Fellows of Harvard University</p>

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -322,7 +322,7 @@ body > footer {
   overflow: auto;
 
   ul {
-    width: 50%;
+    //width: 50%;
     float: right;
     list-style-type: none;
     margin-bottom: 0;


### PR DESCRIPTION
This PR adds a "Newsletter" link to the website's footer.

<img width="1111" alt="Screen Shot 2022-12-08 at 6 11 25 PM" src="https://user-images.githubusercontent.com/625889/206518870-798dadd9-64af-4676-b85d-2a92b1c1bfd2.png">

<img width="492" alt="Screen Shot 2022-12-08 at 6 11 43 PM" src="https://user-images.githubusercontent.com/625889/206518873-ab4aa071-1a1f-4322-a74d-fecd41f159c7.png">

For now it redirects to [the "subscribe" form](https://ocb.to/lawvocado), we may want to redirect to the ["past issues" page](https://us3.campaign-archive.com/home/?u=4290964398813d739f2398db0&id=e097736c6f) 🤷 ?