### PR TITLE
See if an increased line-height....

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -576,6 +576,19 @@ section, .container {
     overflow: auto;
   }
 
+  // use a slightly larger line-height on mobile,
+  // so that if the li contains links, their
+  // border-style underline has enough room to display
+  // (test with mobile safari)
+  li {
+    line-height: 1.6;
+  }
+  @include respond(3) {
+    li {
+      line-height: 1.4;
+    }
+  }
+
   h3, h4 {
     font-size: inherit;
     font-weight: 500;


### PR DESCRIPTION
...fixes the underlining of links in lists on mobile Safari, [reported by @lizadaily](https://hlslil.slack.com/archives/C04FY4NP7GU/p1671492818703009).

Before:
<img src="https://user-images.githubusercontent.com/11020492/208551394-81384b6c-4573-4de9-96c6-207baba7637e.png" width="300" />

Hopefully, after:
<img src="https://user-images.githubusercontent.com/11020492/208551509-d238b62b-3103-4260-b32b-7447aba48153.png" width="300" />

(needs to be tested on a real phone; the emulators on my computer are not exhibiting the same problem)