### PR TITLE
Update content for AI summit page

### DIFF
--- a/app/_scss/variables-mixins-placeholders.scss
+++ b/app/_scss/variables-mixins-placeholders.scss
@@ -7,8 +7,9 @@
 
 // basic grid to keep spacing simple and regular
 $grid: 8px;
-$double: $grid * 2;
 $half: $grid / 2;
+$double: $grid * 2;
+$quad: $grid * 4;
 
 ////////
 //  respond

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -94,7 +94,7 @@ to collect and publish an ever-growing dataset of public domain law at
 </p>
 
 <p>
-  At the end of February 2024 this collection will go fully open as a dataset structured for reading by humans and machines. We are collaborating with friends at Lexis Nexis, Fastcase, and the Free Law Project to ensure the maximum social benefit to this launch. We expect part of the launch will include a public declaration and call for a human right to access the edicts of law.
+  At the end of February 2024 this collection will go fully open as a dataset structured for reading by humans and machines. We are collaborating with friends at LexisNexis, Fastcase, and the Free Law Project to ensure the maximum social benefit to this launch. We expect part of the launch will include a public declaration and call for a human right to access the edicts of law.
 </p>
 
 <h3>Open French Law Chatbot</h3>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -16,7 +16,7 @@ layout: simple-page
 
 <p>
   Note: this page is for the Harvard Law AI Summit on September 19, 2023. This
-  is an invitation only event.
+  is an invitation-only event.
 </p>
 
 <h2>Recommended Readings</h2>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -57,7 +57,8 @@ layout: simple-page
 </p>
 
 <h3>LIL Vector</h3>
-TK
+<p>lil_vector is our community server for experimenting with generative AI technology. Located in LIL space, this machine learning workstation equipped with two A6000 GPUs allows us to freely explore the potential of open-source AI models. 
+But more than a shared compute resource, it is a nascent community hub on which technologists from LIL and beyond share resources and experiments, as we collectively make sense of this AI moment.</p>
 
 <h3>Collaborative Open Legal Data (COLD) Dataset</h3>
 <p>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -127,11 +127,7 @@ the news that an
 </p>
 
 <h3>LIL Vector</h3>
-<p>lil_vector is our community server for experimenting with generative AI technology. Located in LIL space, this machine learning server allows us to freely explore the potential of open-source AI models. </p>
-
-<p>
-  But more than a shared compute resource, it is a nascent community hub on which technologists from LIL and beyond share resources and experiments, as we collectively make sense of this AI moment. 
-</p>
+<p>lil_vector is our community server for experimenting with generative AI technology. Located in LIL space, this machine learning server allows us to freely explore the potential of open-source AI models. But more than a shared compute resource, it is a nascent community hub on which technologists from LIL and beyond share resources and experiments, as we collectively make sense of this AI moment.</p>
 
 <h2>Harvard Library Innovation Lab AI Fund </h2>
 <p>To support this and other work, we have launched a LIL AI Fund to accept gifts and coordinate collaboration with law firms, legal technologists, foundations, and others working at the cutting edge of law, AI, libraries, and society. Contact us to discuss participation.</p>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -124,7 +124,6 @@ the news that an
   responses across all five LLMs justified removing the book from library
   shelves. The case study will be published as part of Banned Books Week in
   October.
-</a>
 </p>
 
 <h3>LIL Vector</h3>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -33,17 +33,17 @@ layout: simple-page
   As this is an invitation-only gathering with an aim to create connections, we
   are sharing the guest list with all participants. This <a href="(https://docs.google.com/spreadsheets/d/1mm7HwnyaOjaE57J1K12vNb-iq5vZ7wrzmhfys7T-oFs/edit#gid=1268423724">participant
   list</a>
-  is public for attendees during the summit and then will be shared directly
-  following the event.
+  is public for attendees during the summit and will be emailed to you after the event. The participant list is not for publication.
 </p>
 
 <hr />
 
 <h2>AI Projects at LIL</h2>
+<p><strong>These projects are all in progress, if you’d like to keep up with them please <a href="https://law.us3.list-manage.com/subscribe?u=4290964398813d739f2398db0&id=e097736c6f">subscribe to our newsletter.</a></strong></p>
 <p>
   Generative AI offers a defining moment where information archives gain the
   ability to answer questions about themselves; to act without human
-  intervention; and even to infer and replicate the processes that created them.
+  intervention; and even to simulate the processes that created them.
   From our perspective at the lab - where we bring library principles to
   technological frontiers - anyone who is concerned with information, access,
   and the law should be aware of and feel empowered to influence the use of
@@ -56,25 +56,11 @@ layout: simple-page
   LIL:
 </p>
 
-<h3>LIL Vector</h3>
-<p>lil_vector is our community server for experimenting with generative AI technology. Located in LIL space, this machine learning workstation equipped with two A6000 GPUs allows us to freely explore the potential of open-source AI models. 
-But more than a shared compute resource, it is a nascent community hub on which technologists from LIL and beyond share resources and experiments, as we collectively make sense of this AI moment.</p>
-
 <h3>Collaborative Open Legal Data (COLD) Dataset</h3>
 <p>
-  In 2017, the Harvard Law Library kicked off the Caselaw Access Project (CAP),
-  by digitizing 360 years of U.S. case law. The Library Innovation Lab (LIL)
-  transformed it into the largest U.S. legal database of its time. Much of this
-  data is public and discoverable for free on LIL's site
-  <a href="https://case.law">case.law.</a>
-</p>
-
-<p>
-  The legal nonprofit <a href="https://free.law/">Free Law Project</a> ingested
-  data from CAP, among other sources of similar data, to create a ever-growing
-  legal dataset and made it available on
-  <a href="http://courtlistener.com/">CourtListener.com</a> as a searchable web
-  portal, via APIs, and bulk exports from their database.
+  The legal nonprofit <a href="https://free.law/">Free Law Project</a> maintains a wide variety of web crawlers 
+to collect and publish an ever-growing dataset of public domain law at
+  <a href="http://courtlistener.com/">CourtListener.com</a>.
 </p>
 
 <p>
@@ -93,25 +79,32 @@ But more than a shared compute resource, it is a nascent community hub on which 
   experiments.
 </p>
 
-<h2>Google books</h2>
-<p>A joint project between the Library Innovation Lab and Harvard Library,
-including Library Technology Services, to compile Harvard’s Google Books data
-and publish it as a dataset that has been optimized for machine learning. In
-2005, Harvard worked with Google to scan over 1 million out-of-copyright books,
-all published before 1923. Those books have never been openly published as a
-dataset, and due to the initial agreement with Google, can only be published by
-a Harvard entity. LIL has been working with Harvard Library LTS to do just that.</p>
+<h3>One Million Books</h3>
+<p>
+  Building on our work on the COLD Dataset, we are working with the Harvard Libraries to identify more public domain datasets that can support computational research and AI experimentation for the public good. One project underway would release a large cache of digitized books and accurate metadata, in collaboration with library technologists and with researchers exploring data set consent and bias issues.
+</p>
 
-<h2>Open French Law Chatbot</h2>
-<p>This experiment explores whether an open-source LLM (Llama 2) can act as both
-translator and French law “expert” if provided with the entirety of French codes
-as “embeddings”. The case study will delve into the potential and limitations of
-open-source LLMs and associated toolchains, and to what extent embeddings models
-and vector databases can augment and “ground” the responses provided by LLMs. In
-addition, LIL will publish the embeddings database containing the entirety of
-French law.</p>
+<h3>Caselaw Access Project and the Right to Access Edicts of Law</h3>
+<p>
+  In 2017, the Harvard Law Library kicked off the Caselaw Access Project (CAP),
+  by digitizing 360 years of U.S. case law. The Library Innovation Lab (LIL)
+  transformed it into the largest U.S. legal database of its time. Much of this
+  data is public and discoverable for free on LIL's site
+  <a href="https://case.law">case.law.</a>
+</p>
 
-<h2>Library Data Trust</h2>
+<p>
+  At the end of February 2024 this collection will go fully open as a dataset structured for reading by humans and machines. We are collaborating with friends at Lexis Nexis, Fastcase, and the Free Law Project to ensure the maximum social benefit to this launch. We expect part of the launch will include a public declaration and call for a human right to access the edicts of law.
+</p>
+
+<h3>Open French Law Chatbot</h3>
+<p>This experiment explores whether an open-source LLM (Llama 2) can act as both translator and French law expert if provided with the entirety of French codes as a vector database. The case study will delve into the potential and limitations of open-source LLMs and associated toolchains, and to what extent embedding models and vector databases can augment and “ground” the responses provided by LLMs. In addition, LIL will publish the embeddings database containing the entirety of French law. 
+ </p>
+
+ <h3>Model Academic Research Agreement</h3>
+ <p>We have drafted and are seeking initial partners for a Model Academic Research Agreement, which would make it easier, faster, and safer for academic researchers to provide advice on unreleased products and models, benefiting both academia and industry.</p>
+
+<h3>Library Data Trust</h3>
 <p>Research into speculative funding structures for libraries and their
 collections. The Library Data Trust would set up a structure whereby libraries
 and archives digitized their collections and made them available for a fee to
@@ -119,7 +112,7 @@ commercial users and for free to everyone else. The goals would be to make more
 collections available to more people while securing the financial future of
 libraries.</p>
 
-<h2>LLMs and Book Ban Benchmark</h2>
+<h3>LLMs and Book Ban Benchmark</h3>
 <p>Are LLMs champions of the freedom to read? The impetus of this experiment was
 the news that an
 <a href="https://www.popsci.com/technology/iowa-chatgpt-book-ban/"
@@ -134,4 +127,12 @@ the news that an
 </a>
 </p>
 
-<p><strong>These projects are all in progress, if you’d like to keep up with them please <a href="https://law.us3.list-manage.com/subscribe?u=4290964398813d739f2398db0&id=e097736c6f">subscribe to our newsletter</a>.</strong></p>
+<h3>LIL Vector</h3>
+<p>lil_vector is our community server for experimenting with generative AI technology. Located in LIL space, this machine learning server allows us to freely explore the potential of open-source AI models. </p>
+
+<p>
+  But more than a shared compute resource, it is a nascent community hub on which technologists from LIL and beyond share resources and experiments, as we collectively make sense of this AI moment. 
+</p>
+
+<h2>Harvard Library Innovation Lab AI Fund </h2>
+<p>To support this and other work, we have launched a LIL AI Fund to accept gifts and coordinate collaboration with law firms, legal technologists, foundations, and others working at the cutting edge of law, AI, libraries, and society. Contact us to discuss participation.</p>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -6,58 +6,131 @@ layout: simple-page
 
 <h1>{{ page.title }}</h1>
 
-<p>The Library Innovation Lab is bringing together experts who are driving the development, adoption, and regulation of AI technology as it rewires society and the law along with it.</p><br>
+<p>
+  <em
+    >The Library Innovation Lab is bringing together experts who are driving the
+    development, adoption, and regulation of AI technology as it rewires society
+    and the law along with it.</em
+  >
+</p>
 
-<strong>This event is invitation only. If you have received an invitation but have not yet filled out an <a href="https://docs.google.com/forms/d/e/1FAIpQLSd3tqle6TSLTqiRUzmdbJsixYsvsEftUMakNxJyrFUwXfqQOQ/viewform?usp=sf_link">RSVP / attendee information form</a>, please do so at your earliest convenience.</strong><br>
+<p>
+  Note: this page is for the Harvard Law AI Summit on September 19, 2023. This
+  is an invitation only event.
+</p>
 
-<br>
+<h2>Recommended Readings</h2>
+<p>
+  We don’t have required readings, but we do have some <a href="https://docs.google.com/document/d/1XNSWdWoAQ-4_r4HzdTsGk8wJmnPB60y1Hr91Devniz4/edit#heading=h.dpq3r4f3vvga">interesting
+  suggestions</a>,
+  many of them written by conference participants. Feel free to skim and check
+  out anything that catches your eye. We will be updating the list as we receive
+  additional suggestions.
+</p>
 
-<h2>Where and When</h2>
+<h2>Guest List</h2>
+<p>
+  As this is an invitation-only gathering with an aim to create connections, we
+  are sharing the guest list with all participants. This <a href="(https://docs.google.com/spreadsheets/d/1mm7HwnyaOjaE57J1K12vNb-iq5vZ7wrzmhfys7T-oFs/edit#gid=1268423724">participant
+  list</a>
+  is public for attendees during the summit and then will be shared directly
+  following the event.
+</p>
 
-<p>The Harvard Law AI Summit will take place September 19, 2023 at the Harvard Law School in Cambridge, Massachusetts. Breakfast and registration will begin at 9am, programming will run from 10am-4pm, and a reception will take place from 5-8pm.</p>
+<hr />
 
-<h2>Directions to Campus</h2>
+<h2>AI Projects at LIL</h2>
+<p>
+  Generative AI offers a defining moment where information archives gain the
+  ability to answer questions about themselves; to act without human
+  intervention; and even to infer and replicate the processes that created them.
+  From our perspective at the lab - where we bring library principles to
+  technological frontiers - anyone who is concerned with information, access,
+  and the law should be aware of and feel empowered to influence the use of
+  generative AIs. We have embarked upon a series of projects in support of that
+  belief.
+</p>
 
-<p>The Summit will be held in the Reginald F. Lewis Law Center on the Harvard Law School campus. The street address is 1557 Massachusetts Avenue, Cambridge, MA 02138.</p>
+<p>
+  In addition to the Harvard Law AI Summit, here’s what else we’ve been up to at
+  LIL:
+</p>
 
-<p>You can find directions to campus via your favorite mode of transportation on the <a href="https://hls.harvard.edu/wp-content/uploads/2022/08/HLS-Map-Directions.pdf">HLS website.</a></p>
+<h3>LIL Vector</h3>
+TK
 
-<p>If you plan to park on campus for the gathering and have not already let us know please contact <a href="mailto:heidolon@law.harvard.edu?subject=Harvard%20Law%20AI%20Summit%20Parking%20Request%20">Harmony Eidolon</a> to arrange a space.</p>
+<h3>Collaborative Open Legal Data (COLD) Dataset</h3>
+<p>
+  In 2017, the Harvard Law Library kicked off the Caselaw Access Project (CAP),
+  by digitizing 360 years of U.S. case law. The Library Innovation Lab (LIL)
+  transformed it into the largest U.S. legal database of its time. Much of this
+  data is public and discoverable for free on LIL's site
+  <a href="https://case.law">case.law.</a>
+</p>
 
-<h2>Suggested Readings</h2>
+<p>
+  The legal nonprofit <a href="https://free.law/">Free Law Project</a> ingested
+  data from CAP, among other sources of similar data, to create a ever-growing
+  legal dataset and made it available on
+  <a href="http://courtlistener.com/">CourtListener.com</a> as a searchable web
+  portal, via APIs, and bulk exports from their database.
+</p>
 
-<ul>
-  <li>Richard Susskind's <a href="https://www.linkedin.com/pulse/ai-law-six-thoughts-richard-susskind/">"Some Thoughts on AI in the Law,"</a> via his newsletter, July 2023.</li>
-  <li>Judge Brantley Starr's <a href="https://www.txnd.uscourts.gov/judge/judge-brantley-starr">Mandatory Certification Regarding Generative Artificial Intelligence,</a> from the US District Court for the Northern District of Texas, May 2023.</li>
-  <li>Stephanie Pacheco's <a href="https://news.bloomberglaw.com/bloomberg-law-analysis/analysis-ai-is-making-a-summer-splash-in-legal-survey-shows-12">"ANALYSIS: AI Is Making a Summer Splash in Legal,"</a> from Bloomberg Law, August 2023.</li>
-  <li>Bruce Schneier And Nathan E. Sanders' <a href="https://www.technologyreview.com/2023/07/28/1076756/six-ways-that-ai-could-change-politics/">"Six Ways That AI Could Change Politics"</a> from MIT Technology Review, July 2023.</li>
-</ul>
+<p>
+  The Library Innovation lab has assembled this data into a dataset suitable for
+  machine learning and made it available on
+  <a href="https://huggingface.co/datasets/harvard-lil/cold-cases"
+    >HuggingFace</a
+  >, along with a
+  <a
+    href="https://datanutrition.org/labels/v3/?id=c29976b2-858c-4f4e-b7d0-c8ef12ce7dbe"
+    >Data Nutrition Label</a
+  >
+  which explains the source of the data and gives guidelines for ethical use.
+  The result is information about over 8 million court cases are available for
+  batch processing, for example in the context of data science and AI
+  experiments.
+</p>
 
-<h2>Schedule</h2>
+<h2>Google books</h2>
+<p>A joint project between the Library Innovation Lab and Harvard Library,
+including Library Technology Services, to compile Harvard’s Google Books data
+and publish it as a dataset that has been optimized for machine learning. In
+2005, Harvard worked with Google to scan over 1 million out-of-copyright books,
+all published before 1923. Those books have never been openly published as a
+dataset, and due to the initial agreement with Google, can only be published by
+a Harvard entity. LIL has been working with Harvard Library LTS to do just that.</p>
 
-  <p><strong>9am</strong> Registration and morning refreshments</p>
-  <p><strong>10am</strong> Welcome Remarks</p>
-  <p><strong>10:30am - 3:45pm</strong> Summit Sessions</p>
-  <p><strong>3:45pm</strong> Closing Remarks</p>
-  <p><strong>4pm</strong> Hotel Break</p>
-  <p><strong>5pm</strong> Reception begins at <a href="https://www.seasontotaste.com">Season to Taste</a></p>
-  <p><strong>6pm</strong> Dinner is served</p>
+<h2>Open French Law Chatbot</h2>
+<p>This experiment explores whether an open-source LLM (Llama 2) can act as both
+translator and French law “expert” if provided with the entirety of French codes
+as “embeddings”. The case study will delve into the potential and limitations of
+open-source LLMs and associated toolchains, and to what extent embeddings models
+and vector databases can augment and “ground” the responses provided by LLMs. In
+addition, LIL will publish the embeddings database containing the entirety of
+French law.</p>
 
-<h2>Hotel Recommendations</h2>
+<h2>Library Data Trust</h2>
+<p>Research into speculative funding structures for libraries and their
+collections. The Library Data Trust would set up a structure whereby libraries
+and archives digitized their collections and made them available for a fee to
+commercial users and for free to everyone else. The goals would be to make more
+collections available to more people while securing the financial future of
+libraries.</p>
 
-<p>There are many hotels in the Cambridge area, but these are a few of our favorites within walking distance.</p>
+<h2>LLMs and Book Ban Benchmark</h2>
+<p>Are LLMs champions of the freedom to read? The impetus of this experiment was
+the news that an
+<a href="https://www.popsci.com/technology/iowa-chatgpt-book-ban/"
+  > Iowa school district relied on ChatGPT’s responses to determine which books
+  to remove from the library.</a> We asked five different LLMs to provide a
+  justification for removing Toni Morrison’s The Bluest Eye from library shelves
+  with the objective of demonstrating how “guardrails” differ among models and
+  assessing the impact of altering the temperature parameter. About 75% of the
+  responses across all five LLMs justified removing the book from library
+  shelves. The case study will be published as part of Banned Books Week in
+  October.
+</a>
+</p>
 
-<ul>
-  <li><a href="http://hotel1868.com/">Hotel 1868</a></li>
-  <li><a href="https://www.theportersquarehotel.com">Porter Square Hotel</a></li>
-  <li><a href="https://www.thehotelveritas.com/">Hotel Veritas</a></li>
-  <li><a href="http://www.afinow.com">A Friendly Inn</a></li>
-</ul>
-
-<h2>Accomodation Information</h2>
-
-<p>We are committed to providing universal access to our event. Please send any accessibility or accommodation requests to <a href="mailto:heidolon@law.harvard.edu?subject=Harvard%20Law%20AI%20Summit%20Accommodation%20Request%20">Harmony Eidolon.</a></p>
-
-<h2>Contacts</h2>
-
-<p>If you have questions regarding the event please reach out to <a href="mailto:cstanton@law.harvard.edu?subject=Harvard%20Law%20AI%20Summit%20Question%20">Clare Stanton.</a></p>
+<p><strong>These projects are all in progress, if you’d like to keep up with them please <a href="https://law.us3.list-manage.com/subscribe?u=4290964398813d739f2398db0&id=e097736c6f">subscribe to our newsletter</a>.</strong></p>

--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -58,25 +58,25 @@ layout: simple-page
 
 <h3>Collaborative Open Legal Data (COLD) Dataset</h3>
 <p>
+  Today we are proud to announce COLD Cases, a research data set to support the open law community.
+</p>
+<p>
   The legal nonprofit <a href="https://free.law/">Free Law Project</a> maintains a wide variety of web crawlers 
 to collect and publish an ever-growing dataset of public domain law at
   <a href="http://courtlistener.com/">CourtListener.com</a>.
 </p>
 
 <p>
-  The Library Innovation lab has assembled this data into a dataset suitable for
-  machine learning and made it available on
+  We have collaborated with FLP to release COLD Cases as a dataset suitable for
+  machine learning
   <a href="https://huggingface.co/datasets/harvard-lil/cold-cases"
-    >HuggingFace</a
-  >, along with a
+    >available on HuggingFace</a
+  > along with a
   <a
     href="https://datanutrition.org/labels/v3/?id=c29976b2-858c-4f4e-b7d0-c8ef12ce7dbe"
     >Data Nutrition Label</a
   >
-  which explains the source of the data and gives guidelines for ethical use.
-  The result is information about over 8 million court cases are available for
-  batch processing, for example in the context of data science and AI
-  experiments.
+  which explains the source of the data and gives guidelines for ethical use. The result is information about over 8 million court cases available for batch processing in the context of data science, AI experiments, and legal tool building.
 </p>
 
 <h3>One Million Books</h3>

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -616,6 +616,10 @@ section, .container {
   p {
     @include body-text;
   }
+  
+  p:first-of-type {
+    margin-top: $quad;
+  }
 
   li {
   line-height: 1.4;
@@ -647,9 +651,19 @@ section, .container {
     }
 
     h2:first-of-type {
-      margin-top: 0;
-    }
+      margin-top: $quad;
+    }  
   }
+
+  hr {
+    margin: $quad 0;
+  }
+}
+
+// Temporary rules for 2023 AI summit page
+body.ai .simple-section {
+  max-width: 75ch;
+  margin: auto;
 }
 
 ////////
@@ -1565,10 +1579,4 @@ section.people-unaffiliated .list {
   span {
     color: $color-black;
   }
-}
-
-// Temporary rule for 2023 AI summit page
-body.ai .simple-section {
-  max-width: 75ch;
-  margin: auto;
 }


### PR DESCRIPTION
## What this Does
- Updates the content on the [AI Summit page](https://lil.law.harvard.edu/about/ai)
- Adds a `quad` SCSS spacing variable
- Adds some additional simple-section styles, to better space content
- Co-located all simple-section styles together for better readability

![Harvard Law AI Summit 2023 _ Library Innovation Lab-additional-Jack-content](https://github.com/harvard-lil/website-static/assets/4039311/f0b3adfc-d043-402b-8de7-c32df9149d52)
