### PR TITLE
fix: Participant list url

### DIFF
--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -31,7 +31,7 @@ layout: simple-page
 <h2>Guest List</h2>
 <p>
   As this is an invitation-only gathering with an aim to create connections, we
-  are sharing the guest list with all participants. This <a href="(https://docs.google.com/spreadsheets/d/1mm7HwnyaOjaE57J1K12vNb-iq5vZ7wrzmhfys7T-oFs/edit#gid=1268423724">participant
+  are sharing the guest list with all participants. This <a href="https://docs.google.com/spreadsheets/d/1mm7HwnyaOjaE57J1K12vNb-iq5vZ7wrzmhfys7T-oFs/edit#gid=0">participant
   list</a>
   is public for attendees during the summit and will be emailed to you after the event. The participant list is not for publication.
 </p>


### PR DESCRIPTION
## What this does 
- Removes an errant "(" that snuck into a url, unnoticed: 

```
<p>
  As this is an invitation-only gathering with an aim to create connections, we
  are sharing the guest list with all participants. This <a href="https://docs.google.com/spreadsheets/d/1mm7HwnyaOjaE57J1K12vNb-iq5vZ7wrzmhfys7T-oFs/edit#gid=0">participant
  list</a>
  is public for attendees during the summit and will be emailed to you after the event. The participant list is not for publication.
</p>
```