### PR TITLE
Make lil.law.harvard.edu/about/ai navigable from homepage

### DIFF
--- a/app/about/ai.html
+++ b/app/about/ai.html
@@ -6,7 +6,7 @@ layout: simple-page
 
 <h1>{{ page.title }}</h1>
 
-<p><strong>These projects are all in progress. If you’d like to keep up with them please <a href="https://law.us3.list-manage.com/subscribe?u=4290964398813d739f2398db0&id=e097736c6f">subscribe to our newsletter.</a></strong></p>
+<p><em>These projects are all in progress. If you’d like to keep up with them please <a href="https://law.us3.list-manage.com/subscribe?u=4290964398813d739f2398db0&id=e097736c6f">subscribe to our newsletter.</a></em></p>
 <p>
   Generative AI offers a defining moment where information archives gain the
   ability to answer questions about themselves; to act without human

--- a/app/index.html
+++ b/app/index.html
@@ -28,6 +28,13 @@ custom-scripts: ['home.js']
       </div>
     </div>
 
+    <div class="slice">
+      <h3>AI Projects</h3>
+      <div class="slice-body">
+        <p>Generative AI offers a defining moment where information archives gain the ability to answer questions about themselves; to act without human intervention; and even to simulate the processes that created them. From our perspective at the lab - where we bring library principles to technological frontiers - anyone who is concerned with information, access, and the law should be aware of and feel empowered to influence the use of generative AIs. We have embarked upon a <a href="{{ site.baseurl }}/about/ai">series of projects</a> in support of that belief.</p>
+      </div>
+    </div>
+
     <a href="{{ site.baseurl }}/about/" role="button" aria-label="Learn more about who we are"><span>Learn more about who we are</span></a>
 
   </div>


### PR DESCRIPTION
See ENG-359.