### PR TITLE
Remove link

### DIFF
--- a/app/_sketches_active/thread-keeper.md
+++ b/app/_sketches_active/thread-keeper.md
@@ -4,8 +4,6 @@
 title: Thread-Keeper
 
 # Optional
-project_website: https://social.perma.cc/
-
 github_repo: https://github.com/harvard-lil/thread-keeper
 
 start_date: November 2022


### PR DESCRIPTION
We can move this from `_sketches_active/` to `_sketches_retired/` later.