### PR TITLE
feat: Add copy and placeholder page for the upcoming CAP event

### DIFF
--- a/app/about/cap-celebration.html
+++ b/app/about/cap-celebration.html
@@ -1,0 +1,26 @@
+---
+title: "Transform: Justice"
+slug: cap-celebration
+layout: simple-page
+---
+
+<h1>{{ page.title }}</h1>
+
+<p>
+  <strong
+    >March 9, 2024<br />
+    The Harvard Law School<br />
+    Cambridge, Massachusetts<br />
+  </strong>
+</p>
+
+<p>
+  The Library Innovation Lab is hosting Transform: Justice at the Harvard Law
+  School on March 9, 2024. A celebration of the full, unqualified release of the
+  data from the <a href="https://case.law">Caselaw Access Project</a> will be the anchor of an event focused on
+  the future of the access to law movement. Speakers across government, academia, and industry will sketch out the opportunities ahead of us for expanding access to legal data and its waterfall effects across society and justice. 
+</p>
+<p>
+  Transform: Justice is a call to action during an inflection point for the world of open legal data. AI is shaking up the way we all think about the power of information and data. Free, accessible, and comprehensive access to the law is foundational to our democracy, and we believe we’re in a moment when big progress can be made. 
+</p>
+<p>Join us for the afternoon of March 9, 2024. Detailed schedule to come.</p>

--- a/app/index.html
+++ b/app/index.html
@@ -22,6 +22,20 @@ custom-scripts: ['home.js']
     </div>
 
     <div class="slice">
+      <h3>Upcoming Event</h3>
+      <div class="slice-body">
+
+
+        <p>
+          <a href="{{ site.baseurl }}/about/cap-celebration"
+            >Transform: Justice</a
+          >
+          is a call to action during an inflection point for the world of open legal data. AI is shaking up the way we all think about the power of information and data. Free, accessible, and comprehensive access to the law is foundational to our democracy, and we believe we’re in a moment when big progress can be made. Learn more here about this public event in March 2024.
+        </p>
+      </div>
+    </div>
+
+    <div class="slice">
       <h3>Democratizing Open Knowledge</h3>
       <div class="slice-body">
         <p><a href="{{ site.baseurl }}/about/democratizing-open-knowledge">Democratizing Open Knowledge</a> is a three-year program at the Library Innovation Lab to explore the goals articulated in Harvard Library’s <a href="https://library.harvard.edu/about/news/2021-03-24/harvard-library-advancing-open-knowledge">Advancing Open Knowledge</a> strategy from a decentralized and generative perspective.</p>


### PR DESCRIPTION
## What this does 
- Adds a new page, at `/about/cap-celebration`
- Adds an additional section to the LIL homepage about the upcoming event

## Screenshots
The updated homepage, featuring the new event section:
![Screenshot 2023-12-18 at 11 34 18 AM](https://github.com/harvard-lil/website-static/assets/4039311/adbda921-c1fa-46e7-b244-dff674c72cc4)

The new CAP celebration page:
![Screenshot 2023-12-18 at 11 25 22 AM](https://github.com/harvard-lil/website-static/assets/4039311/b5a9664f-7412-4044-a4dd-fe5fbbf7e4ac)

## How to test 
- Add a new remote for the `website-static` repo locally 
- Check out the `cap-event-placeholder` branch
- Run `docker-compose up` 
- The updated LIL homepage can be visited at `http://localhost:8080/`