### PR TITLE
Show "featured tags"  navigation on any paginated blog page.

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -86,6 +86,9 @@ defaults:
       custom-footer: false
       sharing-card-type: summary
 
+# Feature Flags
+show_blog_featured_tags: true
+
 ############################################################
 # Site configuration for the Jekyll 3 Pagination Gem
 # The values here represent the defaults if nothing is set

--- a/app/_data/featured_tags.yaml
+++ b/app/_data/featured_tags.yaml
@@ -1,0 +1,3 @@
+- link rot
+- caselaw
+- podcast

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -1,0 +1,14 @@
+{% assign current = page.autopages.display_name|strip | default: 'all' %}
+
+<div class="sleeve">
+  <nav class="posts-filter" aria-label="Featured Tags">
+    <span class="tag" {% if current == "all" %}aria-current="true"{% endif %}>
+      <a href="{{ site.baseurl }}/blog/">all</a>
+    </span>
+    {% for tag in site.data.featured_tags %}
+      <span class="tag" {% if current == tag %}aria-current="true"{% endif %}>
+        <a href="{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/">{{ tag }}</a>
+      </span>
+    {% endfor %}
+  </nav>
+</div>

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -4,14 +4,20 @@
 
 <div class="sleeve">
   <nav class="posts-filter" aria-label="Featured Tags">
-    <span class="tag" {% if current == "all" %}aria-current="true"{% endif %}>
-      <a href="{{ site.baseurl }}/blog/">all</a>
-    </span>
-    {% for tag in site.data.featured_tags %}
-      <span class="tag" {% if current == tag %}aria-current="true"{% endif %}>
-        <a href="{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/">{{ tag }}</a>
-      </span>
-    {% endfor %}
+    <ul>
+      <li>
+        <a class="tag" href="{{ site.baseurl }}/blog/" {% if current == "all" %}aria-current="true"{% endif %}>
+          all
+        </a>
+      </li>
+      {% for tag in site.data.featured_tags %}
+        <li>
+          <a class="tag" href="{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/"{% if current == tag %}aria-current="true"{% endif %}>
+          {{ tag }}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
   </nav>
 </div>
 

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -1,5 +1,7 @@
 {% assign current = page.autopages.display_name|strip | default: 'all' %}
 
+{% if site.show_blog_featured_tags %}
+
 <div class="sleeve">
   <nav class="posts-filter" aria-label="Featured Tags">
     <span class="tag" {% if current == "all" %}aria-current="true"{% endif %}>
@@ -12,3 +14,5 @@
     {% endfor %}
   </nav>
 </div>
+
+{% endif %}

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -6,13 +6,13 @@
   <nav class="posts-filter" aria-label="Featured Tags">
     <ul>
       <li>
-        <a class="tag" href="{{ site.baseurl }}/blog/" {% if current == "all" %}aria-current="true"{% endif %}>
+        <a class="tag" href="{{ site.baseurl }}/blog/"{% if current == "all" %} aria-current="true"{% endif %}>
           all
         </a>
       </li>
       {% for tag in site.data.featured_tags %}
         <li>
-          <a class="tag" href="{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/"{% if current == tag %}aria-current="true"{% endif %}>
+          <a class="tag" href="{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/"{% if current == tag %} aria-current="true"{% endif %}>
           {{ tag }}
           </a>
         </li>

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -8,8 +8,11 @@ custom-css: ['blog']
 ---
 
 <section class="posts-index">
+
+  {% include tag-filter.html %}
+
   <div class="sleeve">
-    <h1>{{ page.autopages.display_name }}</h1>
+    <h1>Posts tagged: "{{ page.autopages.display_name }}"</h1>
     {% for post in paginator.posts %}
       <div class="slice">
         <h2><time class="post-date" datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time></h2>

--- a/app/assets/css/blog.scss
+++ b/app/assets/css/blog.scss
@@ -9,6 +9,10 @@
 ////////////////////////////////////////////////
 //  blog
 
+.posts-filter {
+  margin-bottom: $double * 2 !important;
+  text-align: left;
+}
 
 .posts-index {
   article {
@@ -21,7 +25,7 @@
     border-bottom: none;
   }
 
-  .sleeve:first-of-type article {
+  .sleeve:nth-of-type(2) article {
     border-top: none;
     margin-top: 0;
   }
@@ -234,7 +238,7 @@
 }
 
 @include respond(4) {
-  article, .pagination {
+  article, .pagination, .posts-filter {
     max-width: 596px;
     margin: auto;
     margin-top: 16px;
@@ -268,6 +272,20 @@ footer {
     color: $color-white;
     background-color: $color-electricblue;
   }
+}
+
+.tag[aria-current='true'] {
+    color: $color-white;
+    background-color: $color-electricblue;
+    a {
+      border-bottom: none;
+    }
+
+    &:hover, &:focus,
+    a:hover, a:focus {
+      color: $color-white;
+      background-color: $color-highlight;
+    }
 }
 
 figure.highlight pre {

--- a/app/assets/css/blog.scss
+++ b/app/assets/css/blog.scss
@@ -10,8 +10,26 @@
 //  blog
 
 .posts-filter {
-  margin-bottom: $double * 2 !important;
   text-align: left;
+  margin-top: 0;
+  margin-bottom: $double !important;
+
+  ul {
+    list-style-type: none;
+    padding: 0;
+    margin-bottom: 0;
+  }
+
+  li {
+    display: inline-block;
+  }
+
+  .tag {
+    border-bottom: none;
+    color: white;
+  }
+
+
 }
 
 .posts-index {

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -225,7 +225,7 @@ h2 {
 ////////////////////////////////////////////////
 //  header
 
-nav {
+nav[aria-label="main"] {
   text-align: center;
 
   ul {
@@ -1340,7 +1340,7 @@ a.link-project {
     }
   }
 
-  nav {
+  nav[aria-label="main"] {
     position: absolute;
     bottom: 0;
     left: 0;

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -8,6 +8,9 @@ custom-css: ['blog']
 ---
 
 <section class="posts-index">
+
+{% include tag-filter.html %}
+
 {% for post in paginator.posts %}
   <div class="sleeve">
     <article itemscope itemtype="http://schema.org/BlogPosting">


### PR DESCRIPTION
See ENG-636/ENG-638.

This adds a nav with (an arbitrary set of) featured tags to the top of the blog's index page, and to any other page where you can page through posts with previous/next. I put it behind a global "feature flag" toggle, just in case it turns out folks don't have time to actually tag posts and pick a set of featured flags before the event: we can just turn this off, and the nav will not be included.

The PR does not add the nav to individual blog posts' pages; I thought that would be visually confusing.

I did not spend much time on styling: I re-used the existing styles for tag, and recruited the focus/hover style to highlight the currently-selected tag.

![image](https://github.com/harvard-lil/website-static/assets/11020492/2f4549bd-5279-4e33-b145-12e47d5f1e6f)

![image](https://github.com/harvard-lil/website-static/assets/11020492/c2540ad0-80ee-45d4-bfe5-9b35a33ab72b)

## For review

Let's merge if we engineers are happy enough with it, and the product team can review at their leisure once it's up on stage.