### PR TITLE
Remove product & research manager job listing info

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -2,7 +2,7 @@
     <div class="hiring-announcement">
       <a href="{{ site.baseurl }}/jobs/">
         We're hiring!
-        We're looking for a Senior Software Engineer and a Product &amp; Research Manager.
+        We're looking for a Senior Software Engineer.
       </a>
     </div>
   <header id="header-splash">

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -24,7 +24,6 @@ layout: sectioned-page
             <a href="#staff">Staff positions</a>
             <ul>
               <li><a href="#sse-fs">Senior Software Engineer</a></li>
-              <li><a href="#pr-manager">Product &amp; Research Manager</a></li>
             </ul>
           </li>
           <li>
@@ -98,19 +97,6 @@ layout: sectioned-page
           <em>
             In addition to Harvard's standard application form, please provide a short cover letter explaining how your career trajectory and interests align with our work and mission.
           </em>
-        </p>
-
-        <h3 id="pr-manager">Product &amp; Research Manager</h3>
-        <p>
-           At LIL, Product &amp; Research Managers are the backbone of a varied and wide reaching product process that manages not only consumer-level design and software development, but also technology experimentation and the convening of in-person and virtual events. The ideal candidate is highly organized and goal oriented, thrives in cross-functional collaboration, and is able to quickly develop a strong perspective on the task at hand while remaining flexible to the road ultimately taken. Existing knowledge of libraries and the broader library ecosystem is optional, but a desire to learn about them is a must.
-        </p>
-        <p>
-          <b>To apply:</b>
-          <a href="https://jobs.brassring.com/TGnewUI/Search/home/HomeWithPreLoad?PageType=JobDetails&partnerid=25240&siteid=5341&Areq=63655BR">Application form</a>.
-          <em>
-            In addition to Harvard's standard application form, please provide a short cover letter explaining how your
-            career trajectory and interests align with our work and mission.
-          </em>        
         </p>
       </div>
     </div>


### PR DESCRIPTION
## What this does 
Pulls the listing for the product & research manager, including the mention on the homepage and on the job description page itself. 

## Screenshots
Updated homepage
![Screenshot 2024-02-28 at 11 51 20 AM](https://github.com/harvard-lil/website-static/assets/4039311/19f90b85-749c-4df9-a54e-f9844434f7ea)

Updated list of links
![Screenshot 2024-02-28 at 11 51 26 AM](https://github.com/harvard-lil/website-static/assets/4039311/cb0a32ce-4af8-47cf-ac1a-9bb3f4ef671b)

Updated job listing content area
![Screenshot 2024-02-28 at 11 51 38 AM](https://github.com/harvard-lil/website-static/assets/4039311/64b1071e-e2ad-41f8-939e-2cd25636bebf)

## How To Test
I've discovered that the least-error prone way to check out a branch locally is to not follow the instructions github provides on each PR. It feels much more consistent to:

- Add a new remote for my fork of website-static, named meaningfully (for example, named tinykite)
- Run `git pull tinykite` to make sure you have the latest remote branches
- Run `git checkout remove-product-listing` to checkout this branch
