### PR TITLE
Convert homepage "About" subcategories to tiles

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -1387,6 +1387,11 @@ a.link-project {
   }
 }
 
+// home page's "about" gallery
+// .home .about .logline {
+//   text-align: left;
+// }
+
 // about page, LIL contact info tweaks
 #about-specs, #about-address {
   clear: both;

--- a/app/index.html
+++ b/app/index.html
@@ -42,7 +42,7 @@ custom-scripts: ['home.js']
                class="img-full-width">
         </figure>
         <strong class="title">Democratizing Open Knowledge</strong>
-        <span class="logline">Democratizing Open Knowledge is a three-year program at the Library Innovation Lab to explore the goals articulated in Harvard Library’s Advancing Open Knowledge strategy from a decentralized and generative perspective.</span>
+        <span class="logline">A 3 year program to explore the goals articulated in Harvard Library's Advancing Open Knowledge strategy from a decentralized and generative perspective.</span>
       </a>
 
       <a class="gallery-item" href="{{ site.baseurl }}/about/ai/">
@@ -54,7 +54,7 @@ custom-scripts: ['home.js']
                class="img-full-width">
         </figure>
         <strong class="title">AI Projects</strong>
-        <span class="logline">Generative AI offers a defining moment where information archives gain the ability to answer questions about themselves; to act without human intervention; and even to simulate the processes that created them. From our perspective at the lab - where we bring library principles to technological frontiers - anyone who is concerned with information, access, and the law should be aware of and feel empowered to influence the use of generative AIs. We have embarked upon a series of projects in support of that belief.</span>
+        <span class="logline">Projects to explore how those concerned with information, access, and the law can be aware of and feel empowered to influence the use of generative AIs.</span>
       </a>
 
       <a class="gallery-item" href="{{ site.baseurl }}/blog/">

--- a/app/index.html
+++ b/app/index.html
@@ -23,8 +23,6 @@ custom-scripts: ['home.js']
     <div class="slice">
       <h3>Upcoming Event</h3>
       <div class="slice-body">
-
-
         <p>
           <a href="{{ site.baseurl }}/about/cap-celebration/"
             >Transform: Justice</a
@@ -34,18 +32,42 @@ custom-scripts: ['home.js']
       </div>
     </div>
 
-    <div class="slice">
-      <h3>Democratizing Open Knowledge</h3>
-      <div class="slice-body">
-        <p><a href="{{ site.baseurl }}/about/democratizing-open-knowledge">Democratizing Open Knowledge</a> is a three-year program at the Library Innovation Lab to explore the goals articulated in Harvard Library’s <a href="https://library.harvard.edu/about/news/2021-03-24/harvard-library-advancing-open-knowledge">Advancing Open Knowledge</a> strategy from a decentralized and generative perspective.</p>
-      </div>
-    </div>
+    <div class="gallery-sq">
+      <a class="gallery-item" href="{{ site.baseurl }}/about/democratizing-open-knowledge/">
+        <figure>
+          <img src="{{ site.baseurl }}/assets/thumbs/400x300r/haystacks-thumbnail-1.png"
+               srcset="{{ site.baseurl }}/assets/thumbs/400x300r/haystacks-thumbnail-1.png 1x,
+                       {{ site.baseurl }}/assets/thumbs/800x600r/haystacks-thumbnail-1.png 2x"
+               alt=""
+               class="img-full-width">
+        </figure>
+        <strong class="title">Democratizing Open Knowledge</strong>
+        <span class="logline">Democratizing Open Knowledge is a three-year program at the Library Innovation Lab to explore the goals articulated in Harvard Library’s Advancing Open Knowledge strategy from a decentralized and generative perspective.</span>
+      </a>
 
-    <div class="slice">
-      <h3>AI Projects</h3>
-      <div class="slice-body">
-        <p>Generative AI offers a defining moment where information archives gain the ability to answer questions about themselves; to act without human intervention; and even to simulate the processes that created them. From our perspective at the lab - where we bring library principles to technological frontiers - anyone who is concerned with information, access, and the law should be aware of and feel empowered to influence the use of generative AIs. We have embarked upon a <a href="{{ site.baseurl }}/about/ai">series of projects</a> in support of that belief.</p>
-      </div>
+      <a class="gallery-item" href="{{ site.baseurl }}/about/ai/">
+        <figure>
+          <img src="{{ site.baseurl }}/assets/thumbs/400x300r/timecapsule-thumbnail-3.png"
+               srcset="{{ site.baseurl }}/assets/thumbs/400x300r/timecapsule-thumbnail-3.png 1x,
+                       {{ site.baseurl }}/assets/thumbs/800x600r/timecapsule-thumbnail-3.png 2x"
+               alt=""
+               class="img-full-width">
+        </figure>
+        <strong class="title">AI Projects</strong>
+        <span class="logline">Generative AI offers a defining moment where information archives gain the ability to answer questions about themselves; to act without human intervention; and even to simulate the processes that created them. From our perspective at the lab - where we bring library principles to technological frontiers - anyone who is concerned with information, access, and the law should be aware of and feel empowered to influence the use of generative AIs. We have embarked upon a series of projects in support of that belief.</span>
+      </a>
+
+      <a class="gallery-item" href="{{ site.baseurl }}/blog/">
+        <figure>
+          <img src="{{ site.baseurl }}/assets/thumbs/400x300r/awesome-box-thumbnail-1.png"
+               srcset="{{ site.baseurl }}/assets/thumbs/400x300r/awesome-box-thumbnail-1.png 1x,
+                       {{ site.baseurl }}/assets/thumbs/800x600r/awesome-box-thumbnail-1.png 2x"
+               alt=""
+               class="img-full-width">
+        </figure>
+        <strong class="title">Blog</strong>
+        <span class="logline">Publishing the results of our explorations and sharing take aways with folks across the spectrum of libraries, technology, and law is part of our mission.</span>
+      </a>
     </div>
 
     <a href="{{ site.baseurl }}/about/" role="button" aria-label="Learn more about who we are"><span>Learn more about who we are</span></a>

--- a/app/index.html
+++ b/app/index.html
@@ -26,7 +26,7 @@ custom-scripts: ['home.js']
 
 
         <p>
-          <a href="{{ site.baseurl }}/about/cap-celebration"
+          <a href="{{ site.baseurl }}/about/cap-celebration/"
             >Transform: Justice</a
           >
           is a call to action during an inflection point for the world of open legal data. AI is shaking up the way we all think about the power of information and data. Free, accessible, and comprehensive access to the law is foundational to our democracy, and we believe we’re in a moment when big progress can be made. Learn more here about this public event in March 2024.


### PR DESCRIPTION
See ENG-631.

Right now, I just used the images for Awesome Box, Time Capsule Encryption, and Haystacks as placeholders, since those retired projects' images aren't already being used in the gallery.

Looks like:

![image](https://github.com/harvard-lil/website-static/assets/11020492/405bc88b-3a9a-4329-9ef8-e8000dface72)

There was some discussion of left-aligning the text, so I added commented out CSS for that, to help with further discussion. FWIW, that looks like: 

![image](https://github.com/harvard-lil/website-static/assets/11020492/67fbd298-4456-431c-970f-5ba56be3e1fd)
