### PR TITLE
Revert "Break up long tagline."

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -8,7 +8,7 @@
   <header class="header-splash">
     <div>
       {% include header-splash-logo.html %}
-      <h1 contenteditable="true"><span>Growing knowledge and community</span><span>by bringing library principles</span><span>to technological frontiers.</span></h1>
+      <h1 contenteditable="true">{{ page.title | smartify }}</h1>
     </div>
     {% include nav.html %}
   </header>

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -1395,11 +1395,6 @@ a.link-project {
     // &::first-line {
     //   color: black;
     // }
-    span {
-      display: block;
-      font-weight: bold;
-      color: black;
-    }
 
     @include respond(3) {
       font-size: 40px;


### PR DESCRIPTION
Per discussion, the width of this element will be capped instead of [split into spans](https://github.com/harvard-lil/website-static/pull/510).