### PR TITLE
Tag blog posts

### DIFF
--- a/app/_data/featured_tags.yaml
+++ b/app/_data/featured_tags.yaml
@@ -1,3 +1,4 @@
-- link rot
-- caselaw
-- podcast
+- AI Research
+- Tools
+- Library Principles
+- Fellows Research

--- a/app/_includes/author.html
+++ b/app/_includes/author.html
@@ -3,7 +3,7 @@
   {% for author in include.author %}
     {% assign person_record = site.data.people[author] %}
     {% if forloop.last and forloop.length > 1 %} and {% endif %}
-    <a href="{{ site.baseurl }}/about/#{{person_record.name | slugify }}">{{ person_record.name }}</a>{% if forloop.last != true and forloop.length > 2 %},{% endif %}
+    <a href="{{ site.baseurl }}/about/#{{person_record.name | slugify }}">{{ person_record.name }}</a>{% if forloop.last != true and forloop.length > 2 %}, {% endif %}
   {% endfor %}
   </p>
 {% elsif include.guest-author %}

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -7,7 +7,7 @@
     <ul>
       <li>
         <a class="tag" href="{{ site.baseurl }}/blog/"{% if current == "all" %} aria-current="true"{% endif %}>
-          all
+          All
         </a>
       </li>
       {% for tag in site.data.featured_tags %}

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -19,8 +19,10 @@ custom-css: ['blog']
         <div class="slice-body">
           <a href="{{ post.url}} ">{{ post.title }}</a>
           {% if post.author %}
-            {% assign person_record = site.data.people[post.author] %}
-            <p><small>{{ person_record.name }}</small></p>
+            {% for author in post.author %}
+              {% assign person_record = site.data.people[author] %}
+              <p class="author-list"><small>{{ person_record.name }}</small></p>
+            {% endfor %}
           {% elsif post.guest-author %}
             <p><small>{{ post.guest-author }}</small></p>
           {% endif %}

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -39,7 +39,7 @@ custom-css: ['blog']
     <div class="slice">
       <div class="list-pagination">
         <div class="wrapper">
-          <div class="page_number ">Page: {{ paginator.page }} of {{ paginator.total_pages }}</div>
+          <div class="page_number ">Page {{ paginator.page }} of {{ paginator.total_pages }}</div>
           {% if paginator.previous_page %}
             <a href="{{ paginator.previous_page_path }}" class="small-btn pagination" role="button">Previous</a>
           {% endif %}

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -31,6 +31,7 @@ custom-css: ['blog']
 </section>
 
 <!-- Pagination links -->
+{% if paginator.total_pages > 1 %}
 <section class="list-index-pagination">
   <div class="sleeve">
     <div class="slice">
@@ -48,3 +49,4 @@ custom-css: ['blog']
     </div>
   </div>
 </section>
+{% endif %}

--- a/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
+++ b/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
@@ -11,6 +11,7 @@ tags:
 - link rot
 - million dollar homepage
 - perma
+- Fellows Research
 ---
 
 In 2005, British student Alex Tew had a million-dollar idea. He launched [www.MillionDollarHomepage.com](http://www.milliondollarhomepage.com/), a website that presented initial visitors with nothing but a 1000×1000 canvas of blank pixels. At the cost of $1/pixel, visitors could permanently claim 10×10 blocks of pixels and populate them however they’d like. Pixel blocks could also be embedded with URLs and tooltip text of the buyer’s choosing.

--- a/app/_posts/2018-05-15-the-library-in-library-innovation-lab.md
+++ b/app/_posts/2018-05-15-the-library-in-library-innovation-lab.md
@@ -1,5 +1,5 @@
 ---
-title: The 'Library' in Library Innovation Lab
+title: The ‘Library’ in Library Innovation Lab
 author: ben-steinberg
 tags:
 - Library Principles

--- a/app/_posts/2018-05-15-the-library-in-library-innovation-lab.md
+++ b/app/_posts/2018-05-15-the-library-in-library-innovation-lab.md
@@ -1,6 +1,8 @@
 ---
 title: The 'Library' in Library Innovation Lab
 author: ben-steinberg
+tags:
+- Library Principles
 ---
 A roomful of people sitting in armchairs with laptops may not appear
 at first glance to be a place where library work is happening. It

--- a/app/_posts/2018-07-04-the-cap-tracking-tool.md
+++ b/app/_posts/2018-07-04-the-cap-tracking-tool.md
@@ -2,6 +2,8 @@
 title: The CAP Tracking Tool
 author: andy-silva
 excerpt_separator: <!--more-->
+tags:
+- Tools
 ---
 Evelin Heidel ([@scannopolis](https://twitter.com/scannopolis) on Twitter) recently asked me to document our Caselaw Access Project ([website](https://lil.law.harvard.edu/projects/caselaw-access-project/), [video](https://www.youtube.com/watch?v=kwlN_vhai84)) digitization workflow, and open up the source for the CAP "Tracking Tool." I'll dig into our digitization workflow in my next post, but in this post, I'll discuss the Tracking Tool or TT for short. I created the TT to track CAP's physical and digital objects and their associated metadata. <!--more--> More specifically, it:
 

--- a/app/_posts/2018-10-31-witchcraft-in-u-s-caselaw.md
+++ b/app/_posts/2018-10-31-witchcraft-in-u-s-caselaw.md
@@ -2,6 +2,8 @@
 title: Witchcraft in U.S. Caselaw
 author: anastasia-aizman
 excerpt_separator: <!--more-->
+tags:
+- Tools
 ---
 ![Witchcraft in Law](https://lil-blog-media.s3.amazonaws.com/Screen_Shot_2018-10-31_at_9.51.54_AM.png) 
 

--- a/app/_posts/2019-02-25-the-network-librarian.md
+++ b/app/_posts/2019-02-25-the-network-librarian.md
@@ -1,6 +1,8 @@
 ---
 title: The Network Librarian
 author: ben-steinberg
+tags:
+- Library Principles
 ---
 Last year,
 [Jack Cushman](https://lil.law.harvard.edu/about/#jack-cushman)

--- a/app/_posts/2019-03-27-some-thoughts-on-digital-preservation.md
+++ b/app/_posts/2019-03-27-some-thoughts-on-digital-preservation.md
@@ -2,6 +2,8 @@
 title: Some Thoughts on Digital Preservation
 author: ben-steinberg
 excerpt_separator: <!--more-->
+tags:
+- Library Principles
 ---
 One of the things people often ask about [Perma.cc](https://perma.cc/)
 is how we ensure the preservation of Perma links. <!--more--> There are some

--- a/app/_posts/2019-04-26-colors-in-caselaw.md
+++ b/app/_posts/2019-04-26-colors-in-caselaw.md
@@ -1,6 +1,8 @@
 ---
 title: Colors in Caselaw
 author: anastasia-aizman
+tags:
+- Tools
 ---
 The prospect of having the Caselaw Access Project dataset become public for the first time brings with it the obvious (and wholly necessary) ideas for data parsing: our dataset is vast and the metadata structured (read about the [process](link) to get to this), but the work of parsing the dataset is far from over. For instance, there's a lot of work to be done in parsing individual parties in CAP (like names of judges), we don't yet have a citator, and we still don't know who wins a case and who loses. And for that matter, we don't really know what "winning" and "losing" even means (if you are interested in working on any of these problems and more, start here: [https://case.law/tools/](https://case.law/tools/)). 
 

--- a/app/_posts/2019-06-19-historical-trends-at-the-caselaw-access-project.md
+++ b/app/_posts/2019-06-19-historical-trends-at-the-caselaw-access-project.md
@@ -1,6 +1,8 @@
 ---
 title: Historical Trends at the Caselaw Access Project
 author: kelly-fitzpatrick
+tags:
+- Tools
 ---
 Today we’re excited to share [Historical Trends](https://case.law/trends/), a new way to explore U.S. case law made available by the [Caselaw Access Project](https://case.law/) at Harvard Law School.
 

--- a/app/_posts/2019-07-11-browse-the-bookshelf-of-u-s-case-law-announcing-the-cap-case-browser.md
+++ b/app/_posts/2019-07-11-browse-the-bookshelf-of-u-s-case-law-announcing-the-cap-case-browser.md
@@ -1,6 +1,8 @@
 ---
 title: "Browse the Bookshelf of U.S. Case Law: Announcing the CAP Case Browser"
 author: kelly-fitzpatrick
+tags:
+- Tools
 ---
 Today we’re announcing the [CAP case browser](https://cite.case.law/)! Browse published U.S. case law from 1658 to 2018&mdash;all 40 million pages of it.
 

--- a/app/_posts/2019-09-17-nelson-guest.md
+++ b/app/_posts/2019-09-17-nelson-guest.md
@@ -1,6 +1,8 @@
 ---
 title: "Guest Post: Do Elected and Appointed Judges Write Opinions Differently?"
 guest-author: "Michael Nelson and Steven Morgan"
+tags:
+- Fellows Research
 ---
 [Unlike anywhere else in the world](https://www.jstor.org/stable/10.1086/679017), most judges in the United States today are elected. But it hasn’t always been this way. [Over the past two centuries](https://www.jstor.org/stable/40648483?seq=1#metadata_info_tab_contents), the American states have taken a variety of different paths, alternating through a variety of elective and appointive methods.  [Opponents](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1337&context=facpub) of judicial elections charge that these institutions detract from judicial independence, harm the legitimacy of the judiciary, and put unqualified jurists on the bench; [those](https://www.amazon.com/Elections-Controversies-Electoral-Democracy-Representation/dp/0415991331) who support judicial elections counter that, by publicly involving the American people in the process of judicial selection, judicial elections can enhance judicial legitimacy. To say this has been an intense debate of academic, political, and popular interest is an [understatement](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1052&context=facpub).
 

--- a/app/_posts/2019-10-09-a-thought-on-digitization.md
+++ b/app/_posts/2019-10-09-a-thought-on-digitization.md
@@ -2,6 +2,8 @@
 title: A Thought on Digitization
 author: ben-steinberg
 no-excerpt: true
+tags:
+- Library Principles
 ---
 Although it is excellent, and I recommend it very highly, 
 I had not expected Roy Scranton's _Learning to Die in the

--- a/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
+++ b/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
@@ -2,6 +2,8 @@
 title: "Guest Post: Is the US Supreme Court in lockstep with Congress when it comes to abortion?"
 guest-author: "Abdul Abdulrahim"
 excerpt_separator: <!--more-->
+tags:
+- Fellows Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
+++ b/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
@@ -2,6 +2,8 @@
 title: 'Guest Post: An Empirical Study of Statutory Interpretation in Tax Law'
 guest-author: Jonathan H. Choi
 excerpt_separator: <!--more-->
+tags:
+- Fellows Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2020-10-19-this-is-just-amazing.md
+++ b/app/_posts/2020-10-19-this-is-just-amazing.md
@@ -2,6 +2,8 @@
 title: This Is Just Amazing
 author: ben-steinberg
 excerpt_separator: <!--more-->
+tags:
+- Library Principles
 ---
 The other day, I noticed this on the side of the house.
 

--- a/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
+++ b/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
@@ -2,6 +2,8 @@
 title: Interface Upgrade | Integrating Queries into Search and Case View
 author: andy-gu
 date: 2021-11-10 02:00:00+00:00
+tags:
+- Fellows Research
 ---
 With expanded feature capabilities, users may find writing these queries to be more difficult, especially as researchers increase the complexity of their investigations. To make usage easier, we have integrated the [Trends](https://case.law/trends/) query language into the [Search](https://case.law/search/) and [Case View](https://cite.case.law/) features. From a search query, users can click the Trends button, upon which our servers will automatically convert an existing query into a Trends timeline.
 

--- a/app/_posts/2022-09-13-what-legal-hackers-can-learn-from-libraries.md
+++ b/app/_posts/2022-09-13-what-legal-hackers-can-learn-from-libraries.md
@@ -1,6 +1,8 @@
 ---
 title: "What Legal Hackers Can Learn From Libraries"
 author: jack-cushman
+tags:
+- Library Principles
 ---
 *This is a lightly edited transcript of a talk I gave at the 2022 Legal Hackers International Summit on September 10, 2022.*
 

--- a/app/_posts/2022-09-15-opportunities-and-challenges-of-client-side-playback.md
+++ b/app/_posts/2022-09-15-opportunities-and-challenges-of-client-side-playback.md
@@ -2,6 +2,8 @@
 title: "Web Archiving: Opportunities and Challenges of Client-Side Playback"
 author: matteo-cargnelutti
 excerpt_separator: <!--more-->
+tags:
+- Tools
 ---
 Historically, the complexities of the backend infrastructures needed to play back and embed rich web archives on a website have limited how we explore, showcase and tell stories with the archived web. [Client-side playback](https://blog.conifer.rhizome.org/2019/10/03/client-side-replay.html) is an exciting emerging technology that lifts a lot of those restraints.
 

--- a/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
+++ b/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
@@ -2,6 +2,9 @@
 title: Ethical Collaborative Storytelling
 author: liza-daly
 excerpt_separator: <!--more-->
+tags:
+- Library Principles
+- Fellows Research
 ---
 I started with the idea of a computer-generated story in which audience participation creates copies of the narrative from each person’s point of view. The story would evolve in real time as new users joined and each person’s copy would update accordingly. I called the story *Forks*. After some initial trials, I decided not to launch it because I did not believe the project was securable against harm.
 

--- a/app/_posts/2022-12-20-chatgpt-poems-and-secrets.md
+++ b/app/_posts/2022-12-20-chatgpt-poems-and-secrets.md
@@ -2,6 +2,8 @@
 title: "ChatGPT: Poems and Secrets"
 author: jack-cushman
 excerpt_separator: <!--more-->
+tags:
+- AI Research
 ---
 I've been asking
 [ChatGPT](https://openai.com/blog/chatgpt/) to write some

--- a/app/_posts/2023-01-13-chatgpt-web-archives.md
+++ b/app/_posts/2023-01-13-chatgpt-web-archives.md
@@ -2,6 +2,8 @@
 title: "Towards \"deep fake\" web archives? Trying to forge WARC files using ChatGPT."
 author: matteo-cargnelutti
 excerpt_separator: <!--more-->
+tags:
+- AI Research
 ---
 Chatbots such as [OpenAI's ChatGPT](https://openai.com/blog/chatgpt/) are becoming impressively 
 good at understanding complex requests in "natural" language and generating convincing blocks of 

--- a/app/_posts/2023-01-18-thread-keeper-iipc-webinar.md
+++ b/app/_posts/2023-01-18-thread-keeper-iipc-webinar.md
@@ -2,6 +2,8 @@
 title: "IIPC Technical Speaker Series: Archiving Twitter"
 author: matteo-cargnelutti
 excerpt_separator: <!--more-->
+tags:
+- Tools
 ---
 I was invited by the [International Internet Preservation Consortium (IIPC)](https://netpreserve.org/) 
 to give a webinar on the topic of _"Archiving Twitter"_ on January 12.

--- a/app/_posts/2023-04-13-scoop-witnessing-the-web.md
+++ b/app/_posts/2023-04-13-scoop-witnessing-the-web.md
@@ -2,6 +2,8 @@
 title: "Witnessing the web is hard: Why and how we built the Scoop web archiving capture engine 🍨"
 author: matteo-cargnelutti
 excerpt_separator: <!--more-->
+tags:
+- Tools
 ---
 
 There is no one-size-fits-all when it comes to web archiving techniques, and the variety of tools and services available to capture web content illustrate the wide, ever-growing set of needs in the web archiving community. As these needs evolve, so do the web and the underlying challenges and opportunities that capturing it presents. Our decade of experience running Perma.cc has given our team a vantage point to identify emerging challenges in witnessing the web that we believe extend well beyond our core mission of preserving citations in the legal record. In an effort to expand the utility of our own service and contribute to the wider array of core tools in the web archiving community, we’ve been working on a handful of [Perma Tools](http://tools.perma.cc).

--- a/app/_posts/2023-05-22-provenance-in-the-age-of-generative-ai.md
+++ b/app/_posts/2023-05-22-provenance-in-the-age-of-generative-ai.md
@@ -2,6 +2,9 @@
 title: '"Did ChatGPT really say that?": Provenance in the age of Generative AI.'
 author: matteo-cargnelutti
 excerpt_separator: <!--more-->
+tags:
+- AI Research
+- Library Principles
 ---
 
 > **Prompt**:

--- a/app/_posts/2023-09-25-ai-book-bans-freedom-to-read-case-study.md
+++ b/app/_posts/2023-09-25-ai-book-bans-freedom-to-read-case-study.md
@@ -3,6 +3,9 @@ title: 'AI Book Bans: Testing LLMs Against the Freedom to Read'
 author: [matteo-cargnelutti,kristi-mukk]
 excerpt_separator: <!--more-->
 sharing-image: images/ai-book-bans-lead-graphic.jpg
+tags:
+- AI Research
+- Library Principles
 ---
 
 <a href="https://lil-blog-media.s3.amazonaws.com/ai-book-bans-lead-graphic.png" aria-hidden="true"><img src="https://lil-blog-media.s3.amazonaws.com/ai-book-bans-lead-graphic.png" alt=""/></a>

--- a/app/_posts/2023-11-28-disruptive-innovation-in-libraries.md
+++ b/app/_posts/2023-11-28-disruptive-innovation-in-libraries.md
@@ -2,6 +2,8 @@
 title: 'Conference talk: disruptive innovation in libraries'
 author: jack-cushman
 excerpt_separator: <!--more-->
+tags:
+- Library Principles
 ---
 
 *This piece is adapted from a keynote talk I gave at Innovación y Experiencia del Usuario at Universidad Católica de Argentina on November 1, 2023.*

--- a/app/_posts/2023-11-29-llms-are-universal-translators.md
+++ b/app/_posts/2023-11-29-llms-are-universal-translators.md
@@ -3,6 +3,9 @@ title: 'LLMs are universal translators: on building my own translation tools for
 author: jack-cushman
 excerpt_separator: <!--more-->
 sharing-image: images/statue-of-liberty.png
+
+tags:
+- AI Research
 ---
 
 Here is a picture of the Statue of Liberty doing a TikTok dance, as painted by van Gogh, as interpreted by ChatGPT. This is very relevant to my point and we’ll come back to it.

--- a/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
+++ b/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
@@ -3,6 +3,9 @@ title: The Cost of a Digital Archive
 author: rebecca-kilberg
 excerpt_separator: <!--more-->
 sharing-image: images/perma-cost.png
+tags:
+- Library Principles
+- Fellows Research
 ---
 At LIL, we’ve been providing users with the ability to preserve online sources via [Perma.cc](https://perma.cc/about) since 2013. Running a digital archive puts us in the “forever business”–what’s online today may be gone tomorrow, but that Perma Link you saved should never expire. Promising to host something forever brings with it different challenges than hosting something for a month or a year. There are the technical burdens: How will we guarantee these links stay accessible even as the underlying technologies continue to develop? There are logistical concerns: Where will we put all these files? There’s also a question of cost: Just how much does it cost to store a file forever?
 

--- a/app/_posts/2024-02-12-warc-gpt-an-open-source-tool-for-exploring-web-archives-with-ai.md
+++ b/app/_posts/2024-02-12-warc-gpt-an-open-source-tool-for-exploring-web-archives-with-ai.md
@@ -3,6 +3,9 @@ title: 'WARC-GPT: An Open-Source Tool for Exploring Web Archives Using AI'
 author: [matteo-cargnelutti,kristi-mukk,clare-stanton]
 excerpt_separator: <!--more-->
 sharing-image: images/warc-gpt-banner.png
+tags:
+- AI Research
+- Tools
 ---
 
 <img src="https://lil-blog-media.s3.amazonaws.com/warc-gpt-banner.png" alt=""/>

--- a/app/_posts/2024-02-29-the-cloud.md
+++ b/app/_posts/2024-02-29-the-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: 'The Cloud'
-author: [rebecca-kilberg]
+author: rebecca-kilberg
 excerpt_separator: <!--more-->
 sharing-image: images/exploding-cloud.png
 tags:

--- a/app/_posts/2024-02-29-the-cloud.md
+++ b/app/_posts/2024-02-29-the-cloud.md
@@ -3,6 +3,9 @@ title: 'The Cloud'
 author: [rebecca-kilberg]
 excerpt_separator: <!--more-->
 sharing-image: images/exploding-cloud.png
+tags:
+- Library Principles
+- Fellows Research
 ---
 
 <img src="https://lil-blog-media.s3.amazonaws.com/exploding-cloud.webp" alt="The moment the cloud explodes"/>

--- a/app/assets/css/blog.scss
+++ b/app/assets/css/blog.scss
@@ -228,6 +228,10 @@
   }
 }
 
+p.author-list {
+  margin-bottom: 0;
+}
+
 @include respond(3) {
   .post-title {
     font-size: 40px;


### PR DESCRIPTION
In https://github.com/harvard-lil/website-static/pull/497, we added a set of "featured tags", but we didn't know what the tags would be yet.

This updates the list and applies the tags to the desired posts.

I tweaked a few things about the index pages while I was in there:
- there was a bug for posts with multiple authors
- I set the pagination to only appear when it is necessary
- etc.

![image](https://github.com/harvard-lil/website-static/assets/11020492/4dd32d67-7117-429d-ad9f-f853b6d4fe50)
![image](https://github.com/harvard-lil/website-static/assets/11020492/17ebdd9f-61c1-4bf3-9ad6-bc225b75d650)
![image](https://github.com/harvard-lil/website-static/assets/11020492/d1821305-d304-4753-b118-7b618968e324)
![image](https://github.com/harvard-lil/website-static/assets/11020492/df4064e1-37ea-46e4-8360-afc9ed6bc6d8)
