### PR TITLE
Remove old kerning CSS

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -108,14 +108,6 @@
 
 *, *:before, *:after {
   box-sizing: inherit;
-  text-rendering: optimizeLegibility;
-  -webkit-font-variant-ligatures: common-ligatures;
-  font-variant-ligatures: common-ligatures;
-  -moz-font-feature-settings: "kern=1";
-  -webkit-font-feature-settings: "kern";
-  -moz-font-feature-settings: "kern";
-  font-feature-settings: "kern";
-  font-kerning: normal;
   overflow: hidden;
   position: relative;
 }
@@ -129,7 +121,6 @@ html, body {
 }
 
 body {
-  -webkit-font-smoothing: antialiased;
   font-family: $font-body;
   font-size: $size-body;
   font-weight: 500;
@@ -139,11 +130,6 @@ body {
   background-color: white;
   width: 100%;
   position: relative;
-}
-
-// allow us to override some of the arcane things above
-.no-ligatures {
-  font-variant-ligatures: none;
 }
 
 // normalize sets to "bolder", which is not available with our fonts


### PR DESCRIPTION
We think this old CSS is subtly messing with the new font. Remove for now. We are open to reverting if we are crazy.

![image](https://github.com/harvard-lil/website-static/assets/11020492/ebc314a3-f945-4205-83f4-69b335ee76ff)
 