### PR TITLE
Swap interior logo

### DIFF
--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -1,8 +1,11 @@
 <nav aria-label="main">
   <ul>
     <li>
-      <a href="{{ site.baseurl }}/">
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="18px" height="24px" viewBox="0 0 18 24" version="1.1" class="header-nav-logo"><style>.style0{fill: none;fill-rule: evenodd;}.style1{fill:  #333333;}.style2{fill:  #D9D9D9;}</style><title>nav-logo</title><desc>Created with Sketch.</desc><defs/><g class="style0"><g transform="translate(-17.000000, -265.000000)"><g transform="translate(-111.000000, 252.000000)"><g transform="translate(127.650000, 12.690000)"><g><path d="M0.3 6.3 L0.3 24.3 L11.3 24.3 L11.3 18.3 L6.3 18.3 L6.3 0.3 L0.3 6.3 Z" class="style1"/><path d="M18.4 18.3 L18.4 0.3 L7.3 0.3 L7.3 6.3 L12.3 6.3 L12.3 24.3 L18.4 18.3 Z" class="style2"/></g></g></g></g></g></svg>
+      <a href="{{ site.baseurl }}/" class="nav__logo">
+        <svg aria-hidden="true" width="18" height="24" viewBox="0 0 18 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0 3.42857H13.7143V24L17.1429 20.5714V0H3.42857L0 3.42857Z"/>
+          <path d="M6.85714 6.85714H3.42857V20.5714H10.2857V17.1429H6.85714V6.85714Z"/>
+        </svg>
         <span class="name"><span class="longname">Library Innovation </span>Lab</span>
       </a>
     </li>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -1,8 +1,8 @@
 <nav aria-label="main">
   <ul>
     <li>
-      <a href="{{ site.baseurl }}/" class="nav__logo">
-        <svg aria-hidden="true" width="18" height="24" viewBox="0 0 18 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+      <a href="{{ site.baseurl }}/">
+        <svg class="header-nav-logo" aria-hidden="true" width="18" height="24" viewBox="0 0 18 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
           <path d="M0 3.42857H13.7143V24L17.1429 20.5714V0H3.42857L0 3.42857Z"/>
           <path d="M6.85714 6.85714H3.42857V20.5714H10.2857V17.1429H6.85714V6.85714Z"/>
         </svg>

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -299,6 +299,7 @@ nav[aria-label="main"] {
         padding-top: 0;
         padding-bottom: 0;
         padding-right: 12px;
+        padding-left: 46px;
         @include respond(3) { padding-right: 22px; }
         @include respond(4) { padding-right: 34px; }
       }

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -249,6 +249,7 @@ h2 {
 
 nav[aria-label="main"] {
   text-align: center;
+  padding-left: 32px;
 
   ul {
     padding: 0;
@@ -259,6 +260,12 @@ nav[aria-label="main"] {
     }
   }
 
+  svg {
+    @include respond(2) {
+      margin-right: 0.5rem;
+    }
+  }
+
   li {
     @extend %vcenter-parent;
     float: left;
@@ -266,13 +273,7 @@ nav[aria-label="main"] {
     font-weight: 500;
 
     &:hover {
-      a {
         color: $color-highlight;
-      }
-      // These are for the SVG logo
-      .style1, .style2 {
-        fill: $color-highlight;
-      }
     }
 
     &:first-of-type {
@@ -287,9 +288,10 @@ nav[aria-label="main"] {
       }
       span.longname { @include hide-onmobile-then(inline); }
       a {
+        display: flex;
+        align-items: center;
         padding-top: 0;
         padding-bottom: 0;
-        padding-left: 46px;
         padding-right: 12px;
         @include respond(3) { padding-right: 22px; }
         @include respond(4) { padding-right: 34px; }

--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -249,7 +249,13 @@ h2 {
 
 nav[aria-label="main"] {
   text-align: center;
-  padding-left: 32px;
+
+  .header-nav-logo {
+    position: absolute;
+    display: block;
+    margin-top: -2px;
+    margin-left: -28px;
+  }
 
   ul {
     padding: 0;


### PR DESCRIPTION
## What this does 
Replaces the old LIL logo with the current, beautiful refreshed version. I originally intended to make sure the LIL logo aligned with the rest of the page: 

![Screenshot 2024-03-06 at 11 39 01 AM](https://github.com/harvard-lil/website-static/assets/4039311/fa0c9609-771b-47a4-91cf-d93b8e159e46)

But after checking with Jacob, learned it would be his preference to remain true to the original design. In the midst of making fixes to make that happen, I discovered we removed a css class from the main.css version of the `rebrand` branch of the LIL website — that was being used to achieve this exact thing on the current, live website. So, in pursuit of efficiency, I decided to pull that class back into the codebase (I think it was removed by mistake). 

Which makes this all a much smaller fix than it originally felt like it needed to be, when I did not have the context of the missing CSS class. 

## Screenshot
![Screenshot 2024-03-06 at 11 34 35 AM](https://github.com/harvard-lil/website-static/assets/4039311/12c6a949-c18a-4792-96bf-9f1e4ea66077)
Comparing the updated nav and the live nav 