### PR TITLE
Updates to CAP event page

### DIFF
--- a/app/about/cap-celebration/index.html
+++ b/app/about/cap-celebration/index.html
@@ -25,28 +25,28 @@ layout: simple-page
 <p>Transform: Justice is a call to action during an inflection point for the world of open legal data. AI is shaking up the way we all think about the power of information and data. Free, accessible, and comprehensive access to the law is foundational to our democracy, and we believe we’re in a moment when big progress can be made. 
 </p>
 
+<h2>Live stream</h2>
+
+<p>This event will also be <a href="{{ baseurl }}/about/cap-celebration/stream">live streamed</a>.</p>
+
 <h2 id="schedule">Schedule</h2>
 
-<p>Noon - 1 pm 	The Caselaw Access Project | <br />
+<p><strong>Noon - 1 pm 	The Caselaw Access Project </strong>  
 This month Harvard is releasing a trove of seven million cases from the collection of the law library. Hear how we did it and why it matters from the leaders of the project.
 Feat. Professor Jonathan Zittrain, Adam Ziegler (TrueLaw), Nik Reed (Knowable and LexisNexis), Daniel Lewis (LegalOn) </p>
 
-<p>1 pm - 1:50 pm	The Future with Open Legal Data | <br />
+<p><strong>1 pm - 1:50 pm	The Future with Open Legal Data </strong>
 What does it take to make the law free for everybody? Hear from Mike Lissner, founder of the Free Law Project; Sara Frug, director of the Legal Information Institute; and Angela Jaffee, an account director at vLex and former national programs administrator for the Administrative Office of the United States Courts.</p>
 
-<p>1:50 pm - 2:30 pm	Opportunities Ahead | <br />
+<p><strong>1:50 pm - 2:30 pm	Opportunities Ahead </strong>
 The ability to know the law is a cornerstone of the larger project to build a just society. Remarks from Carl Malamud, founder of Public.Resource.Org; Professor Alexandra Natapoff, of Harvard Law School; and Chief Justice Mark V. Green of the Massachusetts Court of Appeals.
 </p>
 
-<p>2:30 pm - 7 pm Invite-Only Round Tables and Reception</p>
+<p><strong>2:30 pm - 7 pm Invite-Only Round Tables and Reception</strong></p>
 
 <h2>Where and When</h2>
 
 <p>Transform: Justice will take place March 8th, 2024 at the Harvard Law School in Cambridge, Massachusetts. The Harvard community is welcome for lunch, a panel featuring access to law advocates, and a keynote speaker from noon to 2:30pm in the Milstein West conference room. Invited guests will join the Library Innovation Lab team in round tables and dinner reception following the public event.</p>
-
-<h2>Live stream</h2>
-
-<p>Keynotes will also be <a href="{{ baseurl }}/about/cap-celebration/stream">live streamed</a>.</p>
 
 <h2>Directions to Campus</h2>
 


### PR DESCRIPTION
Moving the streaming link towards the top, fixing schedule formatting issues