### PR TITLE
Add some space between cards on the About page.

### DIFF
--- a/app/assets/css/main.scss
+++ b/app/assets/css/main.scss
@@ -917,7 +917,7 @@ a.gallery-item {
     max-width: nth($respond-breakpoints,4) + (6 * $double);
     border-top: none;
     margin-top: 0;
-    padding: 0;
+    padding: 0 $grid;
 
     figure {
       float: none;


### PR DESCRIPTION
Greg noticed that people's profile pictures on the About page were bumping into each other.

When did that happen? Ben and I both swear it didn't used to be that way, despite all evidence to the contrary.

Before:

![image](https://github.com/harvard-lil/website-static/assets/11020492/02f2c13e-b963-43ce-adb2-b1d25c7c8a15)

After:

![image](https://github.com/harvard-lil/website-static/assets/11020492/44b7be80-059e-4d6d-8964-451841df3108)
