### PR TITLE
Fix redundant inclusion of blog css.

### DIFF
--- a/app/_events/harvard-law-ai-summit.md
+++ b/app/_events/harvard-law-ai-summit.md
@@ -3,7 +3,6 @@ title: "Harvard Law AI Summit"
 date: 2023-09-19 19:05:36+00:00
 short_description: "A closed-door gathering of experts exploring AI as a new form of knowledge."
 description: "The Harvard Law AI Summit was an invitation-only gathering across the spectrum of law, government, AI research, civil society and social science. The summit explored how AI as a new form of knowledge is poised to challenge and reshape institutions."
-custom-css: ['blog']
 ---
 
 The Harvard Law AI Summit was an invitation-only gathering across the spectrum of law, government, AI research, civil society and social science. The summit explored how AI as a new form of knowledge is poised to challenge and reshape institutions.

--- a/app/_events/transform-copyright.md
+++ b/app/_events/transform-copyright.md
@@ -3,7 +3,6 @@ title: "Transform: Copyright"
 date: 2024-04-22 19:05:36+00:00
 short_description: "An invite-only workshop for experts trying to reconcile the tensions between AI development and copyright."
 description: "Transform: Copyright was a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and copyright."
-custom-css: ['blog']
 ---
 
 Transform: Copyright was a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and copyright. 

--- a/app/_events/transform-journalism.md
+++ b/app/_events/transform-journalism.md
@@ -3,7 +3,6 @@ title: "Transform: Journalism"
 date: 2024-10-23 19:05:36+00:00
 short_description: "An invite-only workshop for experts trying to reconcile the tensions between AI growth and journalism."
 description: "Transform: Journalism was a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and journalism."
-custom-css: ['blog']
 ---
 
 AI is poised to fundamentally change journalism—its practice, its economics, and its import. In a world where media is so easily generated, how can the relationship between AI and journalism be structured to reaffirm our ability to establish, value, and communicate truth?

--- a/app/_events/transform-justice.md
+++ b/app/_events/transform-justice.md
@@ -3,7 +3,6 @@ title: "Transform: Justice"
 date: 2024-03-08 19:05:36+00:00
 short_description: "A celebration of the full, unqualified release of data from the Caselaw Access Project."
 description: "A celebration of the full, unqualified release of the data from the Caselaw Access Project will be the anchor of an event focused on the future of the access to law movement. Speakers across government, academia, and industry will sketch out the opportunities ahead of us for expanding access to legal data and its waterfall effects across society and justice."
-custom-css: ['blog']
 ---
 
 <img src="{{ site.baseurl }}/assets/images/transform-justice-banner-small.jpg" alt=""/>

--- a/app/_layouts/event.html
+++ b/app/_layouts/event.html
@@ -1,6 +1,6 @@
 ---
 layout: sectioned-page
-custom-css: ['blog']
+custom-css: ['post-content']
 ---
 
 <section class="container pt-80">

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -1,6 +1,6 @@
 ---
 layout: sectioned-page
-custom-css: ['blog']
+custom-css: ['post-content']
 ---
 
 <section class="container pt-50 md:pt-80 pb-100">

--- a/app/_layouts/research.html
+++ b/app/_layouts/research.html
@@ -1,6 +1,6 @@
 ---
 layout: sectioned-page
-custom-css: ['blog']
+custom-css: ['post-content']
 ---
 
 <section class="container">

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -4,7 +4,7 @@ title-tag: Blog
 slug: blog
 pagination:
   enabled: true
-custom-css: ['blog']
+custom-css: ['blog-search']
 ---
 
 <section class="pt-40 md:pt-80 pb-40 md:pb-200">

--- a/app/_research/democratizing-open-knowledge.md
+++ b/app/_research/democratizing-open-knowledge.md
@@ -1,6 +1,5 @@
 ---
 title: "Democratizing Open Knowledge"
-custom-css: ['blog']
 ---
 
 <p>Democratizing Open Knowledge is a three-year program at the Library Innovation Lab to explore the goals articulated in Harvard Library's <a href="https://library.harvard.edu/about/news/2021-03-24/harvard-library-advancing-open-knowledge">Advancing Open Knowledge</a> strategy from a decentralized and generative perspective. If you like what you see here and want to collaborate, <a href="{{ site.baseurl }}/about">get in touch</a>!</p>

--- a/app/_research/librarianship-of-ai.md
+++ b/app/_research/librarianship-of-ai.md
@@ -1,6 +1,5 @@
 ---
 title: "Librarianship of AI"
-custom-css: ['blog']
 ---
 
 For the past year or so, we have been using the term "Librarianship of AI" to describe an emerging practice and guiding framework for sense making in the AI realm via the lens of librarianship. We define Librarianship of AI as “the study of models, their implementation, usage and behavior as a way of helping users make informed decisions and empowering them to use AI responsibly.”

--- a/app/_research/scoop-capture-engine.md
+++ b/app/_research/scoop-capture-engine.md
@@ -1,6 +1,5 @@
 ---
 title: "Scoop Capture Engine"
-custom-css: ['blog']
 ---
 
 [Part of Perma Tools](https://tools.perma.cc/)

--- a/app/_research/wacz-exhibitor.md
+++ b/app/_research/wacz-exhibitor.md
@@ -1,6 +1,5 @@
 ---
 title: "WACZ Exhibitor"
-custom-css: ['blog']
 ---
 
 [Part of Perma Tools](https://tools.perma.cc/)

--- a/app/_research/wacz-signing.md
+++ b/app/_research/wacz-signing.md
@@ -1,6 +1,5 @@
 ---
 title: "WACZ Signing"
-custom-css: ['blog']
 ---
 
 [Part of Perma Tools](https://tools.perma.cc/)

--- a/app/assets/css/blog-search.css
+++ b/app/assets/css/blog-search.css
@@ -1,0 +1,5 @@
+/* if post-grids__search-results, which is the sibling before post-grids__default, has any articles as children hide post-grids__default */
+
+.post-grids__search-results:has(article) ~ .post-grids__default, .post-grids__search-results:has(.no-results) ~ .post-grids__default {
+  display: none;
+}

--- a/app/assets/css/post-content.css
+++ b/app/assets/css/post-content.css
@@ -77,10 +77,3 @@
   transform: scaleX(0);
   transform-origin: 100% 100%;
 }
-
-/* if post-grids__search-results, which is the sibling before post-grids__default, has any articles as children hide post-grids__default */
-
-.post-grids__search-results:has(article) ~ .post-grids__default, .post-grids__search-results:has(.no-results) ~ .post-grids__default {
-  display: none;
-}
-

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -4,7 +4,7 @@ title-tag: Blog
 slug: blog
 pagination:
   enabled: true
-custom-css: ['blog']
+custom-css: ['blog-search']
 ---
 
 <section class="pt-40 md:pt-80 pb-40 md:pb-200">


### PR DESCRIPTION
I noticed that multiple copies of `blog.css` were being included in various locations.

This PR:
- removes the redundant inclusion from the individual events and research items
- splits that css file into two parts, one that styles search, one that styles post content, so that it's clearer why we are including things in various spots at all.

I _think_ this will not break the cache busting code... but we shall see!