### PR TITLE
Fixup wacz-exhibitor links

### DIFF
--- a/app/_research/wacz-exhibitor.md
+++ b/app/_research/wacz-exhibitor.md
@@ -17,4 +17,4 @@ This implementation:
 
 [wacz-exhibitor on GitHub](https://github.com/harvard-lil/wacz-exhibitor)
 
-See also: Live Demo, Blog post
+See also: [Live Demo](https://warcembed-demo.lil.tools/), [Blog post](http://localhost:8080/blog/2022/09/15/opportunities-and-challenges-of-client-side-playback/)

--- a/app/_research/wacz-exhibitor.md
+++ b/app/_research/wacz-exhibitor.md
@@ -11,7 +11,7 @@ Experimental proxy and wrapper boilerplate for safely and efficiently embedding 
 
 This implementation:
 
-* Wraps [Webrecorder's <replay-web-page>](https://replayweb.page/docs/embedding) client-side playback technology.
+* Wraps [Webrecorder's replayweb.page](https://replayweb.page/docs/embedding) client-side playback technology.
 * Serves, proxies and caches web archive files using [NGINX](https://www.nginx.com/).
 * Allows for two-way communication between the embedding website and the embedded archive using post messages.
 


### PR DESCRIPTION
I noticed that two links were missing, and one wasn't being converted from markdown properly; quick fix.