### PR TITLE
Fixup landmarks

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="bg-black text-white pt-60 pb-40">
+<footer aria-label="page footer" class="bg-black text-white pt-60 pb-40">
   <div class="container flex flex-wrap md:grid md:grid-cols-12 md:gap-x-20 md:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] md:col-span-4 md:max-w-[340px]">
       {% include footer-logo.html %}

--- a/app/_layouts/event.html
+++ b/app/_layouts/event.html
@@ -6,7 +6,9 @@ custom-css: ['blog']
 <section class="container pt-80">
   <div class="flex flex-col gap-50 md:gap-120 mb-56">
     <div class="flex flex-col items-start gap-20">
-      <a href="/events" class="label interactive-link dark reverse">Events</a>
+      <nav aria-label="breadcrumbs">
+        <a href="/events" class="label interactive-link dark reverse">Events</a>
+      </nav>
       <div class="flex flex-col md:grid md:grid-cols-3 gap-32 pb-40 md:pb-80 border-b-1 border-black">
         <h1 class="h2">
           {{page.title}}

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -7,7 +7,9 @@ custom-css: ['blog']
   <div class="flex flex-col gap-50 md:gap-120 mb-14 md:mb-56">
     {% include tag-filter.html tags=page.tags %}
     <div class="flex flex-col items-start gap-10 md:gap-20">
-      <a href="/blog" class="label interactive-link dark reverse">Blog</a>
+      <nav aria-label="breadcrumbs">
+        <a href="/blog" class="label interactive-link dark reverse">Blog</a>
+      </nav>
       <div class="flex flex-col md:grid md:grid-cols-3 gap-14 md:gap-32 pb-40 md:pb-80 border-b-1 border-black">
         <h1 class="h2">{{page.title}}</h1>
         <div class="md:col-span-2 body-text max-w-[700px] md:pt-10">

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -4,9 +4,9 @@ layout: sectioned-page
 
 <section class="container">
   <div class="page-hero">
-    <div class="page-hero__eyebrow">
+    <nav aria-label="breadcrumbs" class="page-hero__eyebrow">
       <a href="/projects/" class="interactive-link dark">Projects</a>
-    </div>
+    </nav>
     <h1 class="page-hero__title">{{ page.title }}</h1>
     <h2 class="page-hero__subtitle">{{page.what_does_it_do}}</h2>
   </div>

--- a/app/_layouts/research.html
+++ b/app/_layouts/research.html
@@ -5,9 +5,9 @@ custom-css: ['blog']
 
 <section class="container">
   <div class="page-hero">
-    <div class="page-hero__eyebrow">
+    <nav aria-label="breadcrumbs" class="page-hero__eyebrow">
       <a href="/projects/" class="interactive-link dark">Research</a>
-    </div>
+    </nav>
     <h1 class="page-hero__title">{{ page.title }}</h1>
   </div>
 </section>

--- a/app/_layouts/sectioned-page.html
+++ b/app/_layouts/sectioned-page.html
@@ -6,8 +6,9 @@ layout: default
   {% include header.html %}
 
   <div id="swup" class="transition-main">
-
-    {{ content }}
+    <main>
+      {{ content }}
+    </main>
 
     {% include footer.html %}
 

--- a/app/_layouts/simple-page.html
+++ b/app/_layouts/simple-page.html
@@ -3,9 +3,9 @@ layout: sectioned-page
 ---
 <div class="container">
   <div class="sleeve">
-    <main id="swup" class="simple-section transition-main">
+    <div id="swup" class="simple-section transition-main">
       {{ content }}
-    </main>
+    </div>
   </div>
 </div>
 <script src="{{ site.baseurl }}/assets/javascripts/main.js"></script>


### PR DESCRIPTION
This PR makes a first pass at tidying our landmarks.

- It reintroduces "main" to our pages, by adding that markup back to the usual template, `sectioned-page.html`, and removes it from the more specialized `simple-page.html`... which in fact inherits from `sectioned-page.html` anyway. (Note, pages that use `simple-page.html are broken already; this PR doesn't further break them 🤣 )

- It labels breadcrumb links with little `nav`, in each pace we have one of those.

- It labels the page footer.