### PR TITLE
Blog-related accessibility fixes

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -144,7 +144,7 @@ pagination:
   #permalink: '/page/:num' # Pages are html files, linked jekyll extensionless permalink style.
 
   # Optional the title format for the paginated pages (supports :title for original page title, :num for pagination page number, :max for total number of pages)
-  title: ':title - page :num'
+  title: 'Page :num of :max | :title'
 
   # Limit how many pagenated pages to create (default: 0, means all)
   limit: 0

--- a/app/_config.yml
+++ b/app/_config.yml
@@ -187,7 +187,7 @@ autopages:
     layouts:
       - 'tag_or_category.html'
     # Optional, the title that each category paginate page should get (:cat is replaced by the Category name)
-    title: 'Posts in category :cat'
+    title: 'Posts in category ":cat" | Blog'
     # Optional, the permalink for the  pagination page (:cat is replaced),
     # the pagination permalink path is then appended to this permalink structure
     permalink: '/blog/category/:cat/'
@@ -202,7 +202,7 @@ autopages:
   tags:
     layouts:
       - 'tag_or_category.html'
-    title: 'Posts tagged with :tag' # :tag is replaced by the tag name
+    title: 'Posts tagged ":tag" | Blog' # :tag is replaced by the tag name
     permalink: '/blog/tag/:tag/'
     slugify:
       mode: raw

--- a/app/_includes/blog-search.html
+++ b/app/_includes/blog-search.html
@@ -3,12 +3,12 @@
     <div class="relative md:col-span-1 flex-1">
       <label for="search" class="sr-only">Search for blog posts</label>
       <input id="search" type="text" class="peer rounded-[0px] w-full border-1 border-black px-12 py-8 md:px-24 md:py-12 text-16 md:text-18 focus:outline-none focus:border-[blue]" placeholder="Search for anything" />
-      <div role="button" data-clear-button class="peer-placeholder-shown:hidden cursor-pointer absolute top-1/2 right-20 -translate-y-1/2" aria-label="Clear search">
-        <div aria-hidden class="w-16 h-16 relative">
-          <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-[2px] bg-black rotate-45"></div>
-          <div class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-[2px] bg-black -rotate-45"></div>
-        </div>
-      </div>
+      <button type="button" data-clear-button class="peer-placeholder-shown:hidden cursor-pointer absolute top-1/2 right-20 -translate-y-1/2" aria-label="Clear search">
+        <span aria-hidden class="block w-16 h-16 relative">
+          <span class="block absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-[2px] bg-black rotate-45"></span>
+          <span class="block absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-[2px] bg-black -rotate-45"></span>
+        </span>
+      </button>
     </div>
     <div>
       <button type="submit" class="text-16 md:text-18 text-white px-18 py-9 md:px-20 bg-black md:py-12">Search</button>

--- a/app/_includes/blog-search.html
+++ b/app/_includes/blog-search.html
@@ -1,8 +1,7 @@
 <lil-search>
-  <form class="flex items-center gap-8 md:gap-20 md:grid md:grid-cols-2">
+  <form role='search' aria-label="blog posts" class="flex items-center gap-8 md:gap-20 md:grid md:grid-cols-2">
     <div class="relative md:col-span-1 flex-1">
-      <label for="search" class="sr-only">Search for blog posts</label>
-      <input id="search" type="text" class="peer rounded-[0px] w-full border-1 border-black px-12 py-8 md:px-24 md:py-12 text-16 md:text-18 focus:outline-none focus:border-[blue]" placeholder="Search for anything" />
+      <input id="search" autocomplete="off" type="text" class="peer rounded-[0px] w-full border-1 border-black px-12 py-8 md:px-24 md:py-12 text-16 md:text-18 focus:outline-none focus:border-[blue]" aria-label="Search for blog posts" placeholder="Search for blog posts" aria-description="search results will appear below" />
       <button type="button" data-clear-button class="peer-placeholder-shown:hidden cursor-pointer absolute top-1/2 right-20 -translate-y-1/2" aria-label="Clear search">
         <span aria-hidden class="block w-16 h-16 relative">
           <span class="block absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full h-[2px] bg-black rotate-45"></span>

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -17,6 +17,10 @@ custom-css: ['blog']
     </div>
   </div>
 
+  <div aria-live="assertive" aria-atomic="true" class="sr-only">
+    <div id="summary"></div>
+  </div>
+
   <div class="w-full post-grids">
 
     <div id="list" class="container grid grid-cols-2 gap-16 md:gap-24 md:grid-cols-4 post-grids__search-results">

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -1,7 +1,5 @@
 ---
 layout: sectioned-page
-title-tag: Blog
-slug: blog
 pagination:
   enabled: true
 custom-css: ['blog']

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -42,7 +42,7 @@ custom-css: ['blog']
         {% if finish > total %}
           {% assign finish = total %}
         {% endif %}
-        <div class="container pt-50 md:pt-60">
+        <nav aria-label="results list pagination" class="container pt-50 md:pt-60">
           <div class="w-full pt-14 md:pt-20 border-t-1 border-black flex items-center justify-between body-text">
             <span>{{start}} - {{finish}} of {{ total }}</span>
             <div class="flex items-center gap-24">
@@ -54,7 +54,7 @@ custom-css: ['blog']
             {% endif %}
             </div>
           </div>
-        </div>
+        </nav>
       {% endif %}
     </div>
   </div>

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -26,10 +26,11 @@ function safeDuration(duration) {
 */
 
 class jekyllSearch {
-    constructor(dataSource, searchField, resultsList, form, clearButton) {
+    constructor(dataSource, searchField, resultsList, resultsSummary, form, clearButton) {
       this.dataSource = dataSource
       this.searchField = document.querySelector(searchField)
       this.resultsList = document.querySelector(resultsList)
+      this.resultsSummary = document.querySelector(resultsSummary)
       this.clearButton = document.querySelector(clearButton)
       this.form = form
   
@@ -69,8 +70,10 @@ class jekyllSearch {
       if(this.searchField.value === '') {
         this.resultsList.innerHTML = ''
       } else if (this.searchField.value !== '' && results.length == 0) {
+        this.resultsSummary.innerHTML = '0 results found'
         this.resultsList.innerHTML = `<p class="body-text no-results col-span-2 md:col-span-4">0 results for "${this.searchField.value}"</p>`
       } else {
+        this.resultsSummary.innerHTML = `${results.length} results found`
         this.resultsList.innerHTML = html
       }
     }
@@ -78,8 +81,10 @@ class jekyllSearch {
     reset() {
         this.resultsList.innerHTML = ''
         this.searchField.value = ''
+        this.resultsSummary.innerHTML = 'Search cleared'
         const url = window.location.href?.split('?')[0]
         window.history.pushState('', '', url);
+        this.searchField.focus()
     }
   
     init() {
@@ -113,12 +118,14 @@ class LilSearch extends HTMLElement {
         this.searchFile = '/search.json'
         this.searchInputSelector = '#search'
         this.searchResultsSelector = '#list'
+        this.searchSummarySelector = '#summary'
         this.form = this.querySelector('form');
         this.clearButtonSelector = '[data-clear-button]'
         this.search = new jekyllSearch(
             this.searchFile,
             this.searchInputSelector,
             this.searchResultsSelector,
+            this.searchSummarySelector,
             this.form,
             this.clearButtonSelector
         );

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -104,12 +104,6 @@ class jekyllSearch {
             window.history.pushState('', '', url.href)
         }
       })
-
-      this.searchField.addEventListener('keypress', event => {
-        if (event.keyCode == 13) {
-          event.preventDefault()
-        }
-      })
     }
 }
 

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -44,7 +44,7 @@ custom-css: ['blog']
         {% if finish > total %}
           {% assign finish = total %}
         {% endif %}
-        <div class="container pt-50 md:pt-60">
+        <nav aria-label="results list pagination" class="container pt-50 md:pt-60">
           <div class="w-full pt-14 md:pt-20 border-t-1 border-black flex items-center justify-between body-text">
             <span>{{start}} - {{finish}} of {{ total }}</span>
             <div class="flex items-center gap-24">
@@ -56,7 +56,7 @@ custom-css: ['blog']
             {% endif %}
             </div>
           </div>
-        </div>
+        </nav>
       {% endif %}
     </div>
   </div>

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -17,6 +17,10 @@ custom-css: ['blog']
     </div>
   </div>
 
+  <div aria-live="assertive" aria-atomic="true" class="sr-only">
+    <div id="summary"></div>
+  </div>
+
   <div class="w-full post-grids">
 
     <div id="list" class="container grid grid-cols-2 gap-16 md:gap-24 md:grid-cols-4 post-grids__search-results">

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -1,6 +1,6 @@
 ---
 layout: sectioned-page
-title-tag: Blog
+title: Blog
 slug: blog
 pagination:
   enabled: true


### PR DESCRIPTION
This PR is a collection of accessibility tweaks for the blog. I consider this a first pass; the details could certainly be improved.

- Tag pages, category pages, and paginated pages (e.g., 2 of 3) all have unique title tags
- The search form can be submitted by pressing return/enter
- When new search results are displayed, a message is announced to screen reader users
- When search is cleared, a message is announced to screen reader users, and keyboard focus is returned to the search input
- The button to clear search is now a `<button>` element.
- The blog pagination is now inside a labeled `nav` region
- Assorted other labels and descriptors, where I personally wanted to hear them, when navigating with my screen off. (This could definitely use another pass.)