### PR TITLE
Fixup icons

### DIFF
--- a/app/_includes/about-people-affiliated.html
+++ b/app/_includes/about-people-affiliated.html
@@ -33,16 +33,36 @@
     {% if person.email or person.website or person.twitter or person.github %}
       <ul class="flex items-center gap-12 md:gap-24">
         {% if person.email %}
-          <li><a href="mailto:{{ person.email }}" target="_blank">{% include icon-email.html %}</a></li>
+          <li>
+            <a href="mailto:{{ person.email }}" target="_blank">
+              <span class="sr-only">{{ person.name }}'s email</span>
+              <span aria-hidden="true">{% include icon-email.html %}</span>
+            </a>
+          </li>
         {% endif %}
         {% if person.website %}
-          <li><a href="{{ person.website}}" target="_blank">{% include icon-website.html %}</a></li>
+          <li>
+            <a href="{{ person.website}}" target="_blank">
+              <span class="sr-only">{{ person.name }}'s website</span>
+              <span aria-hidden="true">{% include icon-website.html %}</span>
+            </a>
+          </li>
         {% endif %}
         {% if person.twitter_account_name %}
-          <li><a href="https://www.twitter.com/{{ person.twitter_account_name}}" target="_blank">{% include icon-x.html %}</a></li>
+          <li>
+            <a href="https://www.twitter.com/{{ person.twitter_account_name}}" target="_blank">
+              <span class="sr-only">{{ person.name }} on Twitter</span>
+              <span aria-hidden="true">{% include icon-x.html %}</span>
+            </a>
+          </li>
         {% endif %}
         {% if person.github_account_name %}
-          <li><a href="https://www.github.com/{{ person.github_account_name }}" target="_blank">{% include icon-github.html %}</a></li>
+          <li>
+            <a href="https://www.github.com/{{ person.github_account_name }}" target="_blank">
+              <span class="sr-only">{{ person.name }} on Github</span>
+              <span aria-hidden="true">{% include icon-github.html %}</span>
+            </a>
+          </li>
         {% endif %}
       </ul>
     {% endif %}

--- a/app/_includes/about-people-unaffiliated.html
+++ b/app/_includes/about-people-unaffiliated.html
@@ -1,21 +1,36 @@
 {% assign person = include.person %}
 
 <div class="body-text w-full py-32 border-t-1 border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative">
-  <span class="label md:col-span-3">{{person.name}}</span>
-  <span class="md:col-span-6">{{person.role}}</span>
-  <span class="pt-20 md:pt-0 md:col-span-3 flex md:justify-end">
+  <div class="label md:col-span-3">{{person.name}}</div>
+  <div class="md:col-span-6">{{person.role}}</div>
+  <div class="pt-20 md:pt-0 md:col-span-3 flex md:justify-end">
     {% if person.website or person.twitter_account_name or person.github_account_name %}
-      <span class="flex items-center gap-12 md:gap-24">
+      <ul class="flex items-center gap-12 md:gap-24">
         {% if person.website %}
-          <span class="website"><a href="{{ person.website}}">{% include icon-website.html %}</a></span>
+          <li class="website">
+            <a href="{{ person.website}}">
+              <span class="sr-only">{{ person.name }}'s website</span>
+              <span aria-hidden="true">{% include icon-website.html %}</span>
+            </a>
+          </li>
         {% endif %}
         {% if person.twitter_account_name %}
-          <span class="twitter"><a href="https://www.twitter.com/{{ person.twitter_account_name }}">{% include icon-x.html %}</a></span>
+          <li class="twitter">
+            <a href="https://www.twitter.com/{{ person.twitter_account_name }}">
+              <span class="sr-only">{{ person.name }} on Twitter</span>
+              <span aria-hidden="true">{% include icon-x.html %}</span>
+            </a>
+          </li>
         {% endif %}
         {% if person.github_account_name %}
-          <span class="github"><a href="https://www.github.com/{{ person.github_account_name}}">{% include icon-github.html %}</a></span>
+          <li class="github">
+            <a href="https://www.github.com/{{ person.github_account_name}}">
+              <span class="sr-only">{{ person.name }} on Github</span>
+              <span aria-hidden="true">{% include icon-github.html %}</span>
+            </a>
+          </li>
         {% endif %}
-      </span>
+      </ul>
     {% endif %}
-  </span>
+  </div>
 </div>

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,7 +1,8 @@
 <footer aria-label="page footer" class="bg-black text-white pt-60 pb-40">
   <div class="container flex flex-wrap md:grid md:grid-cols-12 md:gap-x-20 md:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] md:col-span-4 md:max-w-[340px]">
-      {% include footer-logo.html %}
+      <span class="sr-only">Home</span>
+      <span aria-hidden="true">{% include footer-logo.html %}</span>
     </a>
     <ul class="footer-nav flex-1 text-right md:text-left md:col-span-6 md:col-start-7 md:text-right md:grid md:grid-cols-2 md:gap-x-20 md:gap-y-10 text-28 md:text-50 leading-[120%] md:leading-[100%] font-medium">
       <li>
@@ -24,9 +25,18 @@
       </li>
     </ul>
     <div class="md:col-span-12 flex items-center justify-end gap-15 w-full self-end pt-32 pb-40 md:pt-0 md:pb-0">
-      <a href="{{ site.github_url}}" target="_blank">{% include icon-github.html %}</a>
-      <a href="{{ site.twitter_url }}" target="_blank">{% include icon-x.html %}</a>
-      <a href="{{ site.linkedin_url }}" target="_blank">{% include icon-linkedin.html %}</a>
+      <a href="{{ site.github_url}}" target="_blank">
+        <span class="sr-only">LIL on Github</span>
+        <span aria-hidden="true">{% include icon-github.html %}</span>
+      </a>
+      <a href="{{ site.twitter_url }}" target="_blank">
+        <span class="sr-only">LIL on Twitter</span>
+        <span aria-hidden="true">{% include icon-x.html %}</span>
+      </a>
+      <a href="{{ site.linkedin_url }}" target="_blank">
+        <span class="sr-only">LIL on LinkedIn</span>
+        <span aria-hidden="true">{% include icon-linkedin.html %}</span>
+      </a>
     </div>
     <div class="w-full flex flex-col md:flex-row md:items-center md:justify-between md:gap-20 pt-24 border-t-1 border-white md:col-span-12 text-12 md:text-16">
       <div class="flex flex-col md:flex-row md:items-center md:gap-100">

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -14,7 +14,10 @@
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>
       <a href="/" class="logo">
-        {% include header-splash-logo.html %}
+        <span class="sr-only">Home</span>
+        <span aria-hidden="true">
+          {% include header-splash-logo.html %}
+        </span>
       </a>
       <button class="menu-button" aria-expanded="false" aria-label="Open menu">
         <span class="menu-button__bar"></span>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -22,9 +22,18 @@
     </ul>
     <div class="w-full container nav-menu__socials">
       <div class="border-t-1 border-white flex items-center gap-15 pt-20">
-        <a href="{{ site.github_url}}" target="_blank">{% include icon-github.html %}</a>
-        <a href="{{ site.twitter_url }}" target="_blank">{% include icon-x.html %}</a>
-        <a href="{{ site.linkedin_url }}" target="_blank">{% include icon-linkedin.html %}</a>
+        <a href="{{ site.github_url}}" target="_blank">
+          <span class="sr-only">LIL on Github</span>
+          <span aria-hidden="true">{% include icon-github.html %}</span>
+        </a>
+        <a href="{{ site.twitter_url }}" target="_blank">
+          <span class="sr-only">LIL on Twitter</span>
+          <span aria-hidden="true">{% include icon-x.html %}</span>
+        </a>
+        <a href="{{ site.linkedin_url }}" target="_blank">
+          <span class="sr-only">LIL on LinkedIn</span>
+          <span aria-hidden="true">{% include icon-linkedin.html %}</span>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
We have a bunch of icons inside links. For example, to LIL's social media account in the footer. This PR wraps all the icons in an aria-hidden span, so that they aren't announced to screen readers and adds a unique sr-only label for each link.