### PR TITLE
Events page logic

### DIFF
--- a/app/_events/transform-journalism.md
+++ b/app/_events/transform-journalism.md
@@ -1,13 +1,17 @@
 ---
 title: "Transform: Journalism"
 date: 2024-10-23 19:05:36+00:00
+date_informal: Fall 2024
+banner: TJ-SiteBanner-small.jpg
+banner_large: TJ-SiteBanner-large.jpg
 short_description: "An invite-only workshop for experts trying to reconcile the tensions between AI growth and journalism."
 description: "Transform: Journalism was a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and journalism."
+excerpt_separator: <!--more-->
 ---
 
 AI is poised to fundamentally change journalism—its practice, its economics, and its import. In a world where media is so easily generated, how can the relationship between AI and journalism be structured to reaffirm our ability to establish, value, and communicate truth?
 
-To answer this question, The Library Innovation Lab at Harvard is hosting Transform: Journalism, a one-day gathering of key decision-makers and stakeholders from model-makers and journalism agencies to academia and news publications. This private workshop aims to identify a set of shared values and collaborative opportunities that might guide the evolution of AI and journalism toward the sustainable cultivation of truth. Over the course of a day, these thoughtful people will map the landscape, discuss control mechanisms and their trade-offs, and synthesize the ideas that emerge into practicable proposals for adoption.
+To answer this question, the Library Innovation Lab at Harvard is hosting Transform: Journalism, a one-day gathering of key decision-makers and stakeholders from model-makers and journalism agencies to academia and news publications. This private workshop aims to identify a set of shared values and collaborative opportunities that might guide the evolution of AI and journalism toward the sustainable cultivation of truth. <!--more--> Over the course of a day, these thoughtful people will map the landscape, discuss control mechanisms and their trade-offs, and synthesize the ideas that emerge into practicable proposals for adoption.
 
 This event is part of the Library Innovation Lab’s Transform Series, where we convene unique groups of stakeholders across disciplines to transform the future of open knowledge.
 

--- a/app/_events/transform-journalism.md
+++ b/app/_events/transform-journalism.md
@@ -1,11 +1,14 @@
 ---
+# mandatory
 title: "Transform: Journalism"
 date: 2024-10-23 19:05:36+00:00
 date_informal: Fall 2024
-banner: TJ-SiteBanner-small.jpg
-banner_large: TJ-SiteBanner-large.jpg
 short_description: "An invite-only workshop for experts trying to reconcile the tensions between AI growth and journalism."
 description: "Transform: Journalism was a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and journalism."
+
+# optional
+banner: TJ-SiteBanner-small.jpg
+banner_large: TJ-SiteBanner-large.jpg
 excerpt_separator: <!--more-->
 ---
 

--- a/app/events.html
+++ b/app/events.html
@@ -49,7 +49,7 @@ layout: sectioned-page
     <section class="container flex flex-col items-start gap-40">
       <h2 class="h2">Past</h2>
       <div class="flex flex-col items-start w-full">
-        {% assign events = site.events | sort: 'date' | reverse %}
+        {% assign events = site.events | where_exp: 'item','item.date < site.time' | sort: 'date' | reverse %}
         {% for event in events %}
           {% capture linkLabel %}
             <span class="sr-only"> {{ event.title }},</span> More Info

--- a/app/events.html
+++ b/app/events.html
@@ -11,34 +11,40 @@ layout: sectioned-page
 </section>
 
 <div class="flex flex-col gap-56 pb-150">
+
+  {% assign next_event = site.events | where_exp: 'item','item.date >= site.time' | sort: 'date' | first %}
+
+  {% if next_event.banner %}
   <section class="container">
     <div class="w-full relative">
       <figure>
         <picture>
+          {% if next_event.banner_large %}
           <source media="(min-width: 600px)"
-                  srcset="{{ site.baseurl }}/assets/images/TJ-SiteBanner-large.jpg">
-          <source srcset="{{ site.baseurl }}/assets/images/TJ-SiteBanner-small.jpg">
-          <img src="{{ site.baseurl }}/assets/images/TJ-SiteBanner-small.jpg"
+                  srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner_large }}">
+          {% endif %}
+          <source srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner }}">
+          <img src="{{ site.baseurl }}/assets/images/{{ next_event.banner }}"
               alt=""
               class="img-full-width">
         </picture>
       </figure>
     </div>
   </section>
+  {% endif %}
+
   <section class="container">
     <div class="flex flex-col gap-50 md:gap-120">
       <div class="flex flex-col items-start gap-20">
         <div class="label">Next Event</div>
         <div class="flex flex-col md:grid md:grid-cols-3 gap-32 pb-60">
-          <h1 class="h2">Transform: Journalism - Fall 2024</h1>
+          <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
           <div class="md:col-span-2 body-text max-w-[700px] pt-10 flex flex-col items-start gap-50">
-            <p>
-              AI is poised to fundamentally change journalism—its practice, its economics, and its import. In a world where media is so easily generated, how can the relationship between AI and journalism be structured to reaffirm our ability to establish, value, and communicate truth?
-            </p>
-            <p>
-              To answer this question, The Library Innovation Lab is hosting Transform: Journalism, a one-day gathering of key decision-makers and stakeholders from model-makers and journalism agencies to academia and news publications. This private workshop aims to identify a set of shared values and collaborative opportunities that might guide the evolution of AI and journalism toward the sustainable cultivation of truth.
-            </p>
-            {% include arrow-link.html label='<span class="sr-only">Transform: Journalism,</span> More Info' href="/events/transform-journalism" reverse=true %}
+            {{ next_event.excerpt }}
+            {% capture linkLabel %}
+              <span class="sr-only">{{ next_event.title }},</span> More Info
+            {% endcapture %}
+            {% include arrow-link.html label=linkLabel href=next_event.url reverse=true %}
           </div>
         </div>
       </div>

--- a/app/events.html
+++ b/app/events.html
@@ -13,43 +13,44 @@ layout: sectioned-page
 <div class="flex flex-col gap-56 pb-150">
 
   {% assign next_event = site.events | where_exp: 'item','item.date >= site.time' | sort: 'date' | first %}
+  {% if next_event %}
+    {% if next_event.banner %}
+      <section class="container">
+        <div class="w-full relative">
+          <figure>
+            <picture>
+              {% if next_event.banner_large %}
+              <source media="(min-width: 600px)"
+                      srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner_large }}">
+              {% endif %}
+              <source srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner }}">
+              <img src="{{ site.baseurl }}/assets/images/{{ next_event.banner }}"
+                  alt=""
+                  class="img-full-width">
+            </picture>
+          </figure>
+        </div>
+      </section>
+      {% endif %}
 
-  {% if next_event.banner %}
-  <section class="container">
-    <div class="w-full relative">
-      <figure>
-        <picture>
-          {% if next_event.banner_large %}
-          <source media="(min-width: 600px)"
-                  srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner_large }}">
-          {% endif %}
-          <source srcset="{{ site.baseurl }}/assets/images/{{ next_event.banner }}">
-          <img src="{{ site.baseurl }}/assets/images/{{ next_event.banner }}"
-              alt=""
-              class="img-full-width">
-        </picture>
-      </figure>
-    </div>
-  </section>
-  {% endif %}
-
-  <section class="container">
-    <div class="flex flex-col gap-50 md:gap-120">
-      <div class="flex flex-col items-start gap-20">
-        <div class="label">Next Event</div>
-        <div class="flex flex-col md:grid md:grid-cols-3 gap-32 pb-60">
-          <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
-          <div class="md:col-span-2 body-text max-w-[700px] pt-10 flex flex-col items-start gap-50">
-            {{ next_event.excerpt }}
-            {% capture linkLabel %}
-              <span class="sr-only">{{ next_event.title }},</span> More Info
-            {% endcapture %}
-            {% include arrow-link.html label=linkLabel href=next_event.url reverse=true %}
+      <section class="container">
+        <div class="flex flex-col gap-50 md:gap-120">
+          <div class="flex flex-col items-start gap-20">
+            <div class="label">Next Event</div>
+            <div class="flex flex-col md:grid md:grid-cols-3 gap-32 pb-60">
+              <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
+              <div class="md:col-span-2 body-text max-w-[700px] pt-10 flex flex-col items-start gap-50">
+                {{ next_event.excerpt }}
+                {% capture linkLabel %}
+                  <span class="sr-only">{{ next_event.title }},</span> More Info
+                {% endcapture %}
+                {% include arrow-link.html label=linkLabel href=next_event.url reverse=true %}
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
-  </section>
+      </section>
+  {% endif %}
 
   {% if site.events.size > 0 %}
     <section class="container flex flex-col items-start gap-40">


### PR DESCRIPTION
The list of "past" events at the bottom of the events page currently lists _all_ events. This PR adds logic to filter out future events by date. So, if we re-deploy the website the day after an event, it will automatically get moved to the "past" section.

The "next event" section of the page was also manually populated, cutting-and-pasting content from the next event's data file. This PR filters the list of events to find the next upcoming event, if any, and populates the page accordingly.

I plan to check in later about the design of the page, if we don't have any upcoming events. Currently:

![image](https://github.com/user-attachments/assets/4213db39-c3f0-440e-be8a-ec735fb46121)
