### PR TITLE
Auto-populate the "Research" section

### DIFF
--- a/app/_data/additional_research.yaml
+++ b/app/_data/additional_research.yaml
@@ -1,0 +1,12 @@
+
+- title: Banned Books
+  url: /blog/2023/09/25/ai-book-bans-freedom-to-read-case-study/
+  subcategory: AI Explorations
+  order:
+
+- title: WARC-GPT
+  url: /blog/2024/02/12/warc-gpt-an-open-source-tool-for-exploring-web-archives-with-ai/
+  subcategory: AI Explorations
+  order:
+
+

--- a/app/_our_work/democratizing-open-knowledge.md
+++ b/app/_our_work/democratizing-open-knowledge.md
@@ -1,6 +1,6 @@
 ---
 category: research
-subtype: upcoming
+subcategory: Upcoming
 retired: false
 retired_date:
 

--- a/app/_our_work/librarianship-of-ai.md
+++ b/app/_our_work/librarianship-of-ai.md
@@ -1,6 +1,6 @@
 ---
 category: research
-subtype: ai explorations
+subcategory: AI Explorations
 retired: false
 retired_date:
 

--- a/app/_our_work/scoop-capture-engine.md
+++ b/app/_our_work/scoop-capture-engine.md
@@ -1,6 +1,6 @@
 ---
 category: research
-subtype: perma tools
+subcategory: Perma Tools
 retired: false
 retired_date:
 

--- a/app/_our_work/wacz-exhibitor.md
+++ b/app/_our_work/wacz-exhibitor.md
@@ -1,6 +1,6 @@
 ---
 category: research
-subtype: perma tools
+subcategory: Perma Tools
 retired: false
 retired_date:
 

--- a/app/_our_work/wacz-signing.md
+++ b/app/_our_work/wacz-signing.md
@@ -1,6 +1,6 @@
 ---
 category: research
-subtype: perma tools
+subcategory: Perma Tools
 retired: false
 retired_date:
 

--- a/app/_plugins/is_even.rb
+++ b/app/_plugins/is_even.rb
@@ -1,0 +1,11 @@
+module Jekyll
+    module IsEven
+
+        def is_even(number)
+            number.even?
+        end
+
+    end
+end
+
+Liquid::Template.register_filter(Jekyll::IsEven)

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -25,39 +25,34 @@ layout: sectioned-page
         </div>
       </div>
     </div>
+
     <div class="flex flex-col gap-24 md:gap-40">
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full border-b-1 border-black pb-40 md:pb-32">
-        <h3 class="label">AI Explorations</h3>
-        <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
-          <div class="flex flex-col items-start gap-24 body-text">
-            <a href="./librarianship-of-ai/" class="interactive-link dark reverse">Librarianship of AI</a>
-            <a href="{{ site.baseurl }}/blog/2023/09/25/ai-book-bans-freedom-to-read-case-study/" class="interactive-link dark reverse">Banned Books</a>
-          </div>
-          <div class="flex flex-col items-start gap-24 body-text">
-            <a href="{{ site.baseurl }}/blog/2024/02/12/warc-gpt-an-open-source-tool-for-exploring-web-archives-with-ai/" class="interactive-link dark reverse">WARC-GPT</a>
-          </div>
-        </div>
-      </div>
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full border-b-1 border-black pb-40 md:pb-32">
-        <h3 class="label">Perma Tools</h3>
-        <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
-          <div class="flex flex-col items-start gap-24 body-text">
-            <a href="./scoop-capture-engine/" class="interactive-link dark reverse">Scoop Capture Engine</a>
-            <a href="./wacz-exhibitor/" class="interactive-link dark reverse">WACZ Exhibitor</a>
-          </div>
-          <div class="flex flex-col items-start gap-24 body-text">
-            <a href="./wacz-signing/" class="interactive-link dark reverse">WACZ Signing</a>
-          </div>
-        </div>
-      </div>
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full">
-        <h3 class="label">Upcoming</h3>
-        <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
-          <div class="flex flex-col items-start gap-24 body-text">
-            <a href="./democratizing-open-knowledge/" class="interactive-link dark reverse">Democratizing Open Knowledge</a>
+
+      {% assign research = site.our_work | where:"category","research" | where:"retired",false %}
+      {% assign active_research =  research | concat: site.data.additional_research %}
+      {% assign subcategories = active_research | map: 'subcategory' | join: ',' | split: ',' | uniq | sort %}
+
+      {% for category in subcategories %}
+        <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full {% if forloop.last == false %} border-b-1 border-black pb-40 md:pb-32 {% endif %}">
+          <h3 class="label">{{ category }}</h3>
+          <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
+            {% assign this_research = active_research | where:"subcategory",category | sort: 'order' %}
+            {% assign column_length = this_research.size | divided_by: 2 | plus: 1 %}
+            {% assign first_half = this_research | slice:0, column_length %}
+            {% assign second_half = this_research | slice:column_length %}
+            <div class="flex flex-col items-start gap-24 body-text">
+              {% for project in first_half %}
+                <a href="{{ project.url }}" class="interactive-link dark reverse">{{ project.title }}</a>
+              {% endfor %}
+            </div>
+            <div class="flex flex-col items-start gap-24 body-text">
+              {% for project in second_half %}
+                <a href="{{ project.url }}" class="interactive-link dark reverse">{{ project.title }}</a>
+              {% endfor %}
+            </div>
           </div>
         </div>
-      </div>
+      {% endfor %}
     </div>
   </section>
 

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -36,10 +36,19 @@ layout: sectioned-page
         <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full {% if forloop.last == false %} border-b-1 border-black pb-40 md:pb-32 {% endif %}">
           <h3 class="label">{{ category }}</h3>
           <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
+
             {% assign this_research = active_research | where:"subcategory",category | sort: 'order' %}
-            {% assign column_length = this_research.size | divided_by: 2 | plus: 1 %}
+
+            {% assign is_even_length = this_research.size | is_even %}
+            {% if is_even_length %}
+              {% assign column_length = this_research.size | divided_by: 2 %}
+            {% else %}
+              {% assign column_length = this_research.size | divided_by: 2 | plus: 1 %}
+            {% endif %}
+
             {% assign first_half = this_research | slice:0, column_length %}
-            {% assign second_half = this_research | slice:column_length %}
+            {% assign second_half = this_research | slice:column_length, this_research.size %}
+
             <div class="flex flex-col items-start gap-24 body-text">
               {% for project in first_half %}
                 <a href="{{ project.url }}" class="interactive-link dark reverse">{{ project.title }}</a>


### PR DESCRIPTION
Right, now, the "Research" section of the "Our Work" page is hand coded.

This PR populates that content from the `our_work` collection: 
- it filters through `our_work` and selects all projects with category "research"
- it splits them up by subcategory, and then sorts by order
- it prints the links in two columns.

If you want to include research that doesn't have its own page yet, you can add an entry to `additional_research.yaml` with whatever title/link/subcategory you want.

Appearance is unchanged:

![image](https://github.com/user-attachments/assets/ae7a3a86-8b5d-43bf-b45b-9ebd434c202b)

For style, here's a screenshot of testing lists of length 1, 2, 3, and 4... which I'm glad I did, because I had it wrong at first.

![image](https://github.com/user-attachments/assets/6a0f1261-b6ef-4ce0-8238-eb731935ef4b)
