### PR TITLE
Swap in suggested alternative underline style.

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -171,7 +171,7 @@ lil-header.expanded .nav-menu__inner {
   transition: display 500ms ease 300ms
 }
 
-.interactive-link {
+/*.interactive-link {
   position: relative;
 }
 
@@ -206,10 +206,10 @@ lil-header.expanded .nav-menu__inner {
 .interactive-link.reverse:hover:after, a:hover .interactive-link.reverse:after {
   transform: scaleX(0);
   transform-origin: 100% 100%;
-}
+}*/
 
 /* mimics .interactive-link pseudo-underlining, in a way that works on wrapping text */
-.interactive-link-inline:hover, .interactive-link-inline.reverse {
+/*.interactive-link-inline:hover, .interactive-link-inline.reverse {
   text-decoration: underline;
   text-decoration-thickness: .1ch;
   text-underline-offset: 5px;
@@ -217,6 +217,31 @@ lil-header.expanded .nav-menu__inner {
 
 .interactive-link-inline.reverse:hover {
   text-decoration: none;
+}*/
+
+.interactive-link, .interactive-link-inline  {
+  position: relative;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0 100%;
+  background-size: 100% 0;
+  background-repeat: no-repeat;
+  transition: background-size .2s ease;
+}
+
+.interactive-link:hover, .interactive-link-inline:hover {
+  background-size: 100% .1ch;
+}
+
+.interactive-link.dark, .interactive-link-inline.dark {
+  background-image: linear-gradient(#121212, #121212);
+}
+
+.interactive-link.reverse, .interactive-link-inline.reverse {
+  background-size: 100% .1ch;
+}
+
+.interactive-link.reverse:hover, .interactive-link-inline.reverse:hover {
+  background-size: 100% 0;
 }
 
 .label-value {

--- a/app/assets/css/post-content.css
+++ b/app/assets/css/post-content.css
@@ -80,7 +80,7 @@
   padding-left: 20px;
 }
 
-.post-content a:after {
+/*.post-content a:after {
   content: "\00a0";
   position: absolute;
   bottom: 2px;
@@ -96,4 +96,17 @@
 .post-content a:hover:after {
   transform: scaleX(0);
   transform-origin: 100% 100%;
+}*/
+
+.post-content a {
+  position: relative;
+  background-image: linear-gradient(currentColor, currentColor);
+  background-position: 0 100%;
+  background-size: 100% .1ch;
+  background-repeat: no-repeat;
+  transition: background-size .2s ease;
+}
+
+.post-content a:hover {
+  background-size: 100% 0;
 }


### PR DESCRIPTION
The current strategy for underlining links on hover... does not work for text on multiple lines. It can only ever underline just the top line of the text.

Correct underlining:

![image](https://github.com/user-attachments/assets/2638809e-23e2-4e8a-b65a-e5c945d86cfd)

Incorrect underlining:

![image](https://github.com/user-attachments/assets/382e1618-5995-4126-89fa-ebea6e2f59e4)

![image](https://github.com/user-attachments/assets/59f89768-1013-458d-8eb1-84dd21a37674)

We don't know a reliable way to animate underlining left-to-right that works for text that wraps. 

Jack tried a few solutions this AM, and they all were "not great" and "not reliable". 

He suggests swapping in this "subtler fade-in fade-out."

TBD.