### PR TITLE
Small navigation improvements

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -19,7 +19,7 @@
           {% include header-splash-logo.html %}
         </span>
       </a>
-      <button class="menu-button"aria-haspopup="menu" aria-expanded="false" aria-label="Open naviation">
+      <button class="menu-button" aria-haspopup="menu" aria-expanded="false" aria-label="Open naviation">
         <span class="menu-button__bar"></span>
         <span class="menu-button__bar"></span>
       </button>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -19,7 +19,7 @@
           {% include header-splash-logo.html %}
         </span>
       </a>
-      <button class="menu-button" aria-expanded="false" aria-label="Open menu">
+      <button class="menu-button"aria-haspopup="menu" aria-expanded="false" aria-label="Open naviation">
         <span class="menu-button__bar"></span>
         <span class="menu-button__bar"></span>
       </button>

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -1,5 +1,5 @@
-<nav aria-label="main" class="nav-menu">
-  <div class="nav-menu__inner">
+<div  class="nav-menu">
+  <nav aria-label="main" class="nav-menu__inner">
     <ul class="nav-menu__list container">
       <li>
         <a class="interactive-link" href="{{ site.baseurl }}/our-work/">Our Work</a>
@@ -36,6 +36,6 @@
         </a>
       </div>
     </div>
-  </div>
-</nav>
+  </nav>
+</div>
 <div aria-hidden="true" class="nav-menu__overlay"></div>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -130,7 +130,7 @@ lil-header.expanded svg {
 
 .nav-menu__inner {
   @apply md:min-h-[800px];
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 50px;
   align-items: center;
@@ -164,6 +164,11 @@ lil-header.expanded .nav-menu__overlay {
   opacity: 1;
   visibility: visible;
   transition: opacity 500ms ease 300ms, visibility 500ms ease 300ms;
+}
+
+lil-header.expanded .nav-menu__inner {
+  display: flex;
+  transition: display 500ms ease 300ms
 }
 
 .interactive-link {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -175,7 +175,7 @@ class LilHeader extends HTMLElement {
         document.body.style.overflow = 'auto';
         window.removeEventListener('keydown', this.closeOnEscape.bind(this));
         this.classList.remove('expanded');
-        this.menuButton.setAttribute('aria-label', 'Open menu');
+        this.menuButton.setAttribute('aria-label', 'Close navigation');
         this.menuCloseAnimation()
     }
 


### PR DESCRIPTION
This PR includes two things:

1) A hack, to actually remove "hidden" nav links from the tab order and from screen readers when they are visually hidden (otherwise people can/must navigate through them before getting to the content, even if the menu is closed).

2) Tweaks what is announced to screen reader users.

I could not fix the larger display issues with the navigation. Jack suggested we address that separately.