### PR TITLE
Fix responsivity on dropdown menu

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -10,7 +10,7 @@
       </a>
     </lil-marquee>
   {% endif %}
-  <header class="pt-32 container bg-white">
+  <header class="pt-32 container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>
       <a href="/" class="logo">

--- a/app/_includes/nav.html
+++ b/app/_includes/nav.html
@@ -1,4 +1,4 @@
-<div  class="nav-menu">
+<div class="nav-menu">
   <nav aria-label="main" class="nav-menu__inner">
     <ul class="nav-menu__list container">
       <li>
@@ -37,5 +37,6 @@
       </div>
     </div>
   </nav>
+  <div class="nav-menu__spacer"></div>
 </div>
 <div aria-hidden="true" class="nav-menu__overlay"></div>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,3 +1,6 @@
+---
+---
+
 @tailwind base;
 @tailwind utilities;
 
@@ -71,7 +74,7 @@ html {
 }
 
 lil-header.expanded .logo {
-  /* we can't interleave z-indexes inside and outside the menu dropdown,
+  /* we cannot interleave z-indexes inside and outside the menu dropdown,
   so adding some drop shadow to the logo is the next best thing to handle
   cases where the window is short, the menu is scrolled, and menu items
   overlap the logo */

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,6 +1,3 @@
----
----
-
 @tailwind base;
 @tailwind utilities;
 
@@ -52,6 +49,10 @@ strong {
   font-weight: 500;
 }
 
+html {
+  scrollbar-gutter: stable;
+}
+
 .container {
   padding-inline: 40px;
   width: 100%;
@@ -63,6 +64,20 @@ strong {
   .container {
     padding-inline: 20px;
   }
+}
+
+.logo {
+  z-index: 10;
+}
+
+lil-header.expanded .logo {
+  /* we can't interleave z-indexes inside and outside the menu dropdown,
+  so adding some drop shadow to the logo is the next best thing to handle
+  cases where the window is short, the menu is scrolled, and menu items
+  overlap the logo */
+  transition: filter 0.1s ease;
+  transition-delay: 1s;
+  filter: drop-shadow(6px 6px 6px rgba(0, 0, 0, 0.6));
 }
 
 .menu-button {
@@ -85,14 +100,14 @@ strong {
   transition: background-color 300ms ease 400ms, transform 300ms ease;
 }
 
-.menu-button__bar:nth-child(2) {
-  transform: translateY(calc(-50% - 8px));
-}
-
-lil-header.expanded .menu-button .menu-button__bar {
+lil-header.expanded .menu-button__bar {
   transform: translateY(-50%) rotate(45deg);
   background-color: white;
   transition: background-color 300ms ease 300ms, transform 300ms ease;
+} 
+
+.menu-button__bar:nth-child(2) {
+  transform: translateY(calc(-50% - 8px));
 }
 
 lil-header.expanded .menu-button .menu-button__bar:nth-child(2) {
@@ -101,7 +116,7 @@ lil-header.expanded .menu-button .menu-button__bar:nth-child(2) {
 
 lil-header svg {
   transition: color 300ms ease;
-  /* transition-delay: 400ms; */
+  transition-delay: 400ms;
   color: #121212;
 }
 
@@ -116,35 +131,43 @@ lil-header.expanded svg {
 }
 
 .nav-menu {
-  position: absolute;
-  top: 0;
+  display: none;  /* to hide links from tab order; will be turned to flex by js */
+  @apply flex-col;
+  position: fixed;
   left: 0;
-  width: 100%;
-  max-height: 100svh;
-  overflow: scroll;
-  @apply bg-black text-white flex flex-col justify-end md:block;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  clip-path: inset(0 0 100% 0);
+  transition: clip-path 0.3s ease-out, opacity 0.3s ease-out;
+  overflow: auto;
   z-index: 1;
-  padding-block: 40px;
-  clip-path: inset(0% 0% 100% 0%);
 }
 
 .nav-menu__inner {
-  @apply md:min-h-[800px];
-  display: none;
-  flex-direction: column;
+  @apply flex flex-col justify-end bg-black text-white;
   gap: 50px;
   align-items: center;
-  justify-content: end;
+  flex-shrink: 0;
+  flex-grow: 1;
+  padding-block: 40px  
 }
 
 .nav-menu__list {
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(min(100%, 300px), 1fr));
   gap: 15px;
-  font-size: 90px;
-  line-height: 90px;
+  font-size: clamp(24px, 5vw, 90px);
+  line-height: 1;
   font-weight: 500;
+}
+
+.nav-menu__spacer {
+  flex-shrink: 1;
+  flex-grow: 0;
+  flex-basis: 80px;
+  min-height: 0;
 }
 
 .nav-menu__overlay {
@@ -427,11 +450,6 @@ html.is-animating .transition-main {
 
   .label-value .value {
     font-size: 18px;
-  }
-
-  .nav-menu {
-    padding-block: 40px;
-    min-height: 100svh;
   }
   
   .nav-menu__list {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -171,14 +171,6 @@ class LilHeader extends HTMLElement {
         }
     }
 
-    setTabindex(index) {
-        /* the menu uses transitions, so we can't use display: none to
-        remove elements from the tab order */
-        this.links?.forEach(link => {
-            link.setAttribute('tabindex', index);
-        });
-    }
-
     closeMenu() {
         this.expanded = false;
         this.menuButton.setAttribute('aria-expanded', this.expanded);

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -144,10 +144,13 @@ class LilHeader extends HTMLElement {
         super();
         this.expanded = false;
         this.menuButton = this.querySelector('.menu-button');
-        this.menu = this.querySelector('.nav-menu');
         this.overlay = this.querySelector('.nav-menu__overlay');
-        this.links = this.querySelectorAll('.nav-menu a');
         this.logo = this.querySelector('.logo');
+        this.header = this.querySelector('header');
+
+        this.menu = this.querySelector('.nav-menu');
+        this.links = this.menu.querySelectorAll('a');
+        this.inner = this.menu.querySelector('.nav-menu__inner');
 
         this.menuButton.addEventListener('click', this.toggleMenu.bind(this));
         this.overlay.addEventListener('click', this.toggleMenu.bind(this));
@@ -166,6 +169,14 @@ class LilHeader extends HTMLElement {
         if (event.key === 'Escape' && this.expanded) {
             this.toggleMenu();
         }
+    }
+
+    setTabindex(index) {
+        /* the menu uses transitions, so we can't use display: none to
+        remove elements from the tab order */
+        this.links?.forEach(link => {
+            link.setAttribute('tabindex', index);
+        });
     }
 
     closeMenu() {
@@ -187,6 +198,7 @@ class LilHeader extends HTMLElement {
         if (this.expanded) {
             document.body.style.overflow = 'hidden';
             window.addEventListener('keydown', this.closeOnEscape.bind(this));
+            this.inner.style.paddingTop = `${this.header.getBoundingClientRect().bottom+40}px`;
             this.classList.add('expanded');
             this.menuButton.setAttribute('aria-label', 'Close menu');
             this.menuOpenAnimation()
@@ -201,6 +213,9 @@ class LilHeader extends HTMLElement {
     }
 
     menuOpenAnimation() {
+        // when closed, menu will be none to keep out of tab order
+        gsap.to(this.menu, {duration: 0, display: 'flex'})
+
         gsap.to(this.menu, {
             duration: safeDuration(0.95),
             ease: 'expo.inOut',
@@ -257,6 +272,8 @@ class LilHeader extends HTMLElement {
             opacity: 0,
             y: -40,
         })
+
+        gsap.to(this.menu, {duration: safeDuration(0.6), display: 'none'})
     }
 }
 


### PR DESCRIPTION
Update dropdown menu so it handles short windows as desired:
- First the 80px of translucent space at the bottom goes to zero.
- Then space between the logo and menu items goes to zero.
- Then menu becomes scrollable.

Also:
- use `scrollbar-gutter: stable` so scrollbars don't pop in and out -- should be fine since all of our pages scroll.
- scale menu item font sizes so menu items don't wrap at medium widths.