### PR TITLE
Accordion accessibility

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -334,7 +334,7 @@ lil-header.expanded .nav-menu__inner {
   transition: transform 300ms ease;
 }
 
-.expandable__icon div {
+.expandable__icon span {
   width: 18px;
   height: 1.5px;
   background: #121212;
@@ -345,7 +345,7 @@ lil-header.expanded .nav-menu__inner {
   transition: transform 300ms ease;
 }
 
-.expandable__icon div:nth-child(1) {
+.expandable__icon span:nth-child(1) {
   transform: translate(-50%, -50%) rotate(90deg);
   transition: transform 300ms ease;
 }
@@ -360,7 +360,7 @@ lil-header.expanded .nav-menu__inner {
   transition: transform 300ms ease;
 }
 
-.expandable.expanded .expandable__icon div:nth-child(2) {
+.expandable.expanded .expandable__icon span:nth-child(2) {
   transform: translate(-50%, -50%) rotate(-90deg);
   transition: transform 300ms ease;
 }
@@ -474,7 +474,7 @@ html.is-animating .transition-main {
     height: 28px;
   }
 
-  .expandable__icon div {
+  .expandable__icon span {
     width: 14px;
   }
 

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -366,6 +366,7 @@ lil-header.expanded .nav-menu__inner {
 }
 
 .expandable__content {
+  display: none;
   opacity: 0;
   height: 0;
   overflow: hidden;

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -279,6 +279,7 @@ class LilExpandable extends HTMLElement {
         super();
         this.expanded = false;
         this.toggle = this.querySelector('.expandable__toggle');
+        this.button = this.querySelector('.expandable__icon');
         this.content = this.querySelector('.expandable__content');
 
         this.toggle.addEventListener('click', this.handleToggleClick.bind(this));
@@ -303,8 +304,7 @@ class LilExpandable extends HTMLElement {
     openExpandable() {
         this.expanded = true;
         this.classList.add('expanded')
-        this.content.setAttribute('aria-hidden', false);
-        this.toggle.setAttribute('aria-expanded', true);
+        this.button.setAttribute('aria-expanded', true);
         this.openExpandableContent();
         this.closeAllExpandables()
     }
@@ -312,8 +312,7 @@ class LilExpandable extends HTMLElement {
     closeExpandable() {
         this.expanded = false;
         this.classList.remove('expanded')
-        this.content.setAttribute('aria-hidden', true);
-        this.toggle.setAttribute('aria-expanded', false);
+        this.button.setAttribute('aria-expanded', false);
         this.closeExpandableContent();
     }
 

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -318,6 +318,7 @@ class LilExpandable extends HTMLElement {
     }
 
     openExpandableContent() {
+        this.content.style.display = 'block';
         gsap.to(this.content, {
             duration: safeDuration(0.6),
             ease: 'power4.inOut',
@@ -333,6 +334,12 @@ class LilExpandable extends HTMLElement {
             height: 0,
             opacity: 0,
         })
+        gsap.to(this.content, {
+            duration: safeDuration(0.6),
+            ease: 'power4.inOut',
+            display: 'none',
+        })
+
     }
 }
 

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -33,13 +33,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">About Us</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -56,13 +56,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Why work with us?</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -84,13 +84,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Location</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -102,13 +102,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Equity, diversity, inclusion, belonging and antiracism</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -132,13 +132,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Software Engineering Manager</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>Our Software Engineering Manager leads a team of software engineers, technologists, and academic collaborators to build open source software for both experimentation and production. The ideal candidate will be ready to mentor and support an enthusiastic and creative team; get their hands dirty solving hard technical problems; and work with the rest of LIL’s senior leadership to set goals for the organization.</p>
@@ -155,13 +155,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Research assistant / student fellow</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -196,13 +196,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <div role="button" class="expandable__toggle" aria-expanded="false">
+          <button type="button" class="expandable__toggle" aria-expanded="false">
             <span class="expandable__toggle--title">Fellows</span>
-            <div class="expandable__icon">
-              <div></div>
-              <div></div>
-            </div>
-          </div>
+            <span class="expandable__icon">
+              <span></span>
+              <span></span>
+            </span>
+          </button>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -33,13 +33,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">About Us</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle">
+            <h3 id="about-us" class="expandable__toggle--title">About Us</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="about-us">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -56,13 +56,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Why work with us?</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle">
+            <h3 id="why" class="expandable__toggle--title">Why work with us?</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="why">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -84,13 +84,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Location</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle">
+            <h3 id="location" class="expandable__toggle--title">Location</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="location">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -102,13 +102,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Equity, diversity, inclusion, belonging and antiracism</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle">
+            <h3 id="ediba" class="expandable__toggle--title">Equity, diversity, inclusion, belonging and antiracism</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="ediba">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -132,13 +132,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Software Engineering Manager</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle" >
+            <h3 id="sem" class="expandable__toggle--title">Software Engineering Manager</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="sem">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>Our Software Engineering Manager leads a team of software engineers, technologists, and academic collaborators to build open source software for both experimentation and production. The ideal candidate will be ready to mentor and support an enthusiastic and creative team; get their hands dirty solving hard technical problems; and work with the rest of LIL’s senior leadership to set goals for the organization.</p>
@@ -155,13 +155,13 @@ layout: default
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Research assistant / student fellow</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle">
+            <h3 id="research-assistant" class="expandable__toggle--title">Research assistant / student fellow</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="research-assistant">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>
@@ -196,13 +196,13 @@ layout: default
           </div>
         </lil-expandable>
         <lil-expandable class="expandable">
-          <button type="button" class="expandable__toggle" aria-expanded="false">
-            <span class="expandable__toggle--title">Fellows</span>
-            <span class="expandable__icon">
+          <div class="expandable__toggle" >
+            <h3 id="fellows" class="expandable__toggle--title">Fellows</h3>
+            <button type="button" class="expandable__icon" aria-expanded="false" aria-labelledby="fellows">
               <span></span>
               <span></span>
-            </span>
-          </button>
+            </button>
+          </div>
           <div class="expandable__content">
             <div class="expandable__content--inner">
               <p>


### PR DESCRIPTION
The accordion on the careers page is coded in such a way that, keyboard users and screenreader users tab to links in the hidden content, even when that drawer is closed. And, keyboard users and screenreader users cannot open or close accordion drawers.

This PR adds a hack to actually remove content from the DOM when hidden: setting `display: none` by default, adding `display: block` before the drawer is animated open, and then animating back to `display: none` after the close-drawer animation completes.

It also switches the toggle icon from a contentless `<span>` to a button, `aria-labelled` by the matching section heading...  which I also switched to be headings. 

So, now you should be able to tab to these buttons and activate them with spacebar or enter, and you should _not_ be able to tab to links in the hidden content. And, each job listing should now appear in the headings list.