### PR TITLE
Add upcoming events section

### DIFF
--- a/app/events.html
+++ b/app/events.html
@@ -52,12 +52,34 @@ layout: default
       </section>
   {% endif %}
 
-  {% if site.events.size > 0 %}
-    <section class="container flex flex-col items-start gap-40">
+  {% assign upcoming_events = site.events | where_exp: 'item','item.date > site.time' | sort: 'date' | reverse %}
+  {% if upcoming_events.size > 0 %}
+    <section class="container flex flex-col items-start gap-10">
+      <h2 class="h2">Upcoming</h2>
+      <div class="flex flex-col items-start w-full">
+
+        {% for event in upcoming_events %}
+          {% capture linkLabel %}
+            <span class="sr-only"> {{ event.title }},</span> More Info
+          {% endcapture %}
+          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+            <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
+            <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
+            <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">
+              {% include arrow-link.html label=linkLabel href=event.url target=target card_link="true" %}
+            </span>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+
+  {% assign past_events = site.events | where_exp: 'item','item.date < site.time' | sort: 'date' | reverse %}
+  {% if past_events.size > 0 %}
+    <section class="container flex flex-col items-start gap-10">
       <h2 class="h2">Past</h2>
       <div class="flex flex-col items-start w-full">
-        {% assign events = site.events | where_exp: 'item','item.date < site.time' | sort: 'date' | reverse %}
-        {% for event in events %}
+        {% for event in past_events %}
           {% capture linkLabel %}
             <span class="sr-only"> {{ event.title }},</span> More Info
           {% endcapture %}


### PR DESCRIPTION
This PR adds an "Upcoming" section to the events page, between "Next Event" And "Past". It lists the next event, too. It appears even if there is only one upcoming event.

Looks like this:
![image](https://github.com/user-attachments/assets/fca3a84a-3549-480c-a46c-024366b107f2)

I note that the final underline and the bottom spacing are incorrect; we've noted that elsewhere on the site too, and can fix altogether in one go.
