### PR TITLE
Fix for browser back/forward buttons w/blog search

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -352,6 +352,9 @@ function setupCustomElements() {
 function setupSwup() {
     const swup = new Swup({
         plugins: [new SwupHeadPlugin()],
+        skipPopStateHandling: (event) => {
+          event.url?.contains('blog') || event.state?.source !== 'swup'
+        },
     });
 }
 


### PR DESCRIPTION
This version of the site uses [swup](https://swup.js.org/) for page transitions. It does all kinds of fancy stuff, including stuff with `popstate`.

We noticed that if you search for different terms in the blog, and then use your browser's back/forward buttons to navigate between searches, the interface doesn't update as expected. It turns out that is because of something `swup` is doing on that page. 

This PR disabled swup's handling of popstate events on the blog page, so that the above works as expected (at least in the browsers I tested: Firefox and in Chrome).

I didn't notice anything different afterwards, including: I still see the animated transition to other pages, if, for instance, clicking the footer link to "Our Work" from the blog. I think that means turning popstate handling off on blog pages has no visual effect... or has only an effect that is so subtle, I'm not picking up on it.