### PR TITLE
Add Perma Links to project's news listings

### DIFF
--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -60,7 +60,7 @@ layout: default
             <span class="col-span-6">{% include arrow-link-inline.html label=article.title href=article.url target="_blank"%}</span>
             {% if article.archived_url %}
               <span class="col-span-3">
-                <a class="interactive-link float-right" href="{{ article.archived_url}}"><img class="inline h-[20px]" src="{{ site.baseurl }}/assets/images/perma-logo.svg" alt="Archived at Perma.cc: {{ article.title }}"></a>
+                <a class="interactive-link float-right" href="{{ article.archived_url}}"><img class="inline h-[20px]" src="{{ site.baseurl }}/assets/images/perma-logo.svg" alt="Archived at Perma.cc: {{ article.title | xml_escape }}"></a>
               </span>
             {% endif %}
           </div>

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -58,6 +58,11 @@ layout: default
               <span class="align-middle">{{ article.date | date: "%m/%d/%y" }}</span>
             </span>
             <span class="col-span-6">{% include arrow-link-inline.html label=article.title href=article.url target="_blank"%}</span>
+            {% if article.archived_url %}
+              <span class="col-span-3">
+                <a class="interactive-link float-right" href="{{ article.archived_url}}"><img class="inline h-[20px]" src="{{ site.baseurl }}/assets/images/perma-logo.svg" alt="Archived at Perma.cc: {{ article.title }}"></a>
+              </span>
+            {% endif %}
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
See LIL-2549.

On the [old/current website](https://lil.law.harvard.edu/projects/perma-cc/), we include two links to each item: one to the live web, one to a Perma Link of the item in question... both as a best citation practice, and as a mini advertisement for Perma.

This was missing from the redesign. We decided to put them back.

This is my swing at something that looks... okay, maybe?

![image](https://github.com/user-attachments/assets/336fe821-e1a1-4319-9ec5-d21ffc73c1b2)

I have no emotional investment in this particular idea; would happily implement some other design.