### PR TITLE
Refactor duplicative contact sections

### DIFF
--- a/app/_includes/contact-section.html
+++ b/app/_includes/contact-section.html
@@ -1,0 +1,35 @@
+<section class="container pb-100 md:pb-200">
+  <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
+    <h2 class="h2">{{ include.heading }}</h2>
+    <div class="md:col-span-2 body-text flex flex-col gap-50 pt-24 flex flex-col md:grid md:grid-cols-2 gap-24 md:gap-32">
+      <div class="flex flex-col gap-50">
+        <div class="label-value">
+          <h3 class="label">Email</h3>
+          <a href="mailto:lil@law.harvard.edu" class="value interactive-link dark reverse">lil@law.harvard.edu</a>
+        </div>
+        <div class="label-value">
+          <h3 class="label">Contact us in person</h3>
+          <address class="value flex flex-col not-italic">
+            <span>The Reginald F. Lewis Law Center</span>
+            <span>1557 Massachusetts Avenue</span>
+            <span>Cambridge, MA 02138</span>
+          </address>
+          {% include arrow-link.html label="Map" href="https://www.google.com/maps/place/1557+Massachusetts+Ave,+Cambridge,+MA+02138/@42.3782483,-71.1213313,17z/data=!3m1!4b1!4m5!3m4!1s0x89e37741bde17be1:0xf64e9368998f6967!8m2!3d42.3782444!4d-71.1191426" target="_blank" reverse=true %}
+        </div>
+      </div>
+      <div class="flex flex-col gap-32">
+        <div class="label-value">
+          <h3 class="label">Newsletter</h3>
+          <p class="value max-w-[330px]">
+            Get updates on our latest projects and research.
+          </p>
+          {% include arrow-link.html label="Sign Up" href="https://ocb.to/lawvocado" target="_blank" reverse=true %}
+        </div>
+        <div class="label-value">
+          <h3 class="label">GitHub</h3>
+          {% include arrow-link.html label="GitHub" href=site.github_url target="_blank" reverse=true %}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/_includes/contact-section.html
+++ b/app/_includes/contact-section.html
@@ -5,7 +5,7 @@
       <div class="flex flex-col gap-50">
         <div class="label-value">
           <h3 class="label">Email</h3>
-          <a href="mailto:lil@law.harvard.edu" class="value interactive-link dark reverse">lil@law.harvard.edu</a>
+          <a href="mailto:{{ site.email }}" class="value interactive-link dark reverse">{{ site.email }}</a>
         </div>
         <div class="label-value">
           <h3 class="label">Contact us in person</h3>

--- a/app/contact/index.html
+++ b/app/contact/index.html
@@ -12,38 +12,4 @@ layout: default
   </div>
 </section>
 
-<section class="container pb-100 md:pb-200">
-  <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
-    <h2 class="h2">Get in touch</h2>
-    <div class="md:col-span-2 body-text flex flex-col gap-50 pt-24 flex flex-col md:grid md:grid-cols-2 gap-24 md:gap-32">
-      <div class="flex flex-col gap-50">
-        <div class="label-value">
-          <h3 class="label">Email</h3>
-          <a href="mailto:{{ site.email }}" class="value interactive-link dark reverse">{{ site.email }}</a>
-        </div>
-        <div class="label-value">
-          <h3 class="label">Contact us in person</h3>
-          <address class="value flex flex-col not-italic">
-            <span>The Reginald F. Lewis Law Center</span>
-            <span>1557 Massachusetts Avenue</span>
-            <span>Cambridge, MA 02138</span>
-          </address>
-          {% include arrow-link.html label="Map" href="https://www.google.com/maps/place/1557+Massachusetts+Ave,+Cambridge,+MA+02138/@42.3782483,-71.1213313,17z/data=!3m1!4b1!4m5!3m4!1s0x89e37741bde17be1:0xf64e9368998f6967!8m2!3d42.3782444!4d-71.1191426" target="_blank" reverse=true %}
-        </div>
-      </div>
-      <div class="flex flex-col gap-32">
-        <div class="label-value">
-          <h3 class="label">Newsletter</h3>
-          <p class="value max-w-[330px]">
-            Get updates on our latest projects and research.
-          </p>
-          {% include arrow-link.html label="Sign Up" href="https://ocb.to/lawvocado" target="_blank" reverse=true %}
-        </div>
-        <div class="label-value">
-          <h3 class="label">GitHub</h3>
-          {% include arrow-link.html label="GitHub" href=site.github_url target="_blank" reverse=true %}
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+{% include contact-section.html heading="Get In Touch" %}

--- a/app/index.html
+++ b/app/index.html
@@ -32,7 +32,7 @@ sharing-card-type: summary_large_image
   </div>
 </div>
 
-<div class="flex flex-col gap-50 md:gap-80 pb-120 md:pb-220">
+<div class="flex flex-col gap-50 md:gap-80">
   {% assign featured_projects = site.our_work | where:"featured",true | sort: "order" %}
   <div class="flex flex-col">
     {% for project in featured_projects %}

--- a/app/index.html
+++ b/app/index.html
@@ -78,39 +78,6 @@ sharing-card-type: summary_large_image
         {% include arrow-link.html label="View All Projects" href="/our-work/" %}
       </div>
     </div>
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
-      <h2 class="h2">Contact Us</h2>
-      <div class="md:col-span-2 body-text flex flex-col pt-24 flex flex-col md:grid md:grid-cols-2 gap-40">
-        <div class="flex flex-col gap-40 md:gap-50">
-          <div class="label-value">
-            <h3 class="label">Email</h3>
-            <a href="mailto:{{ site.email }}" class="value interactive-link dark reverse">{{ site.email }}</a>
-          </div>
-          <div class="label-value">
-            <h3 class="label">Contact us in person</h3>
-            <address class="value flex flex-col not-italic">
-              <span>The Reginald F. Lewis Law Center</span>
-              <span>1557 Massachusetts Avenue</span>
-              <span>Cambridge, MA 02138</span>
-            </address>
-            {% include arrow-link.html label="Map" href="#" target="_blank" reverse=true %}
-          </div>
-        </div>
-        <div class="flex flex-col gap-40 md:gap-50">
-          <div class="label-value">
-            <h3 class="label">Newsletter</h3>
-            <p class="value max-w-[330px]">
-              Get updates on our latest projects and research.
-            </p>
-            {% include arrow-link.html label="Sign Up" href="https://ocb.to/lawvocado" target="_blank" reverse=true %}
-          </div>
-          <div class="label-value">
-            <h3 class="label">GitHub</h3>
-            {% include arrow-link.html label="GitHub" href=site.github_url target="_blank" reverse=true %}
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
-
+  {% include contact-section.html heading="Contact Us" %}
 </div>


### PR DESCRIPTION
We had "Contact Us" blocks on both the homepage and the Contact page whose content was duplicative, albeit with some slight differences. This consolidates the two blocks into a new include, `contact-section.html`.

Note: this refactor also caused a weird `padding-bottom` issue on the homepage, which I "fixed" by removing some `pb-XX` classes from the main `div`. It seems like we've been fixing lots of other spacing issues so perhaps someone else knows a less arbitrary approach?