### PR TITLE
First pass: people gallery in small viewports

### DIFF
--- a/app/_includes/about-people-affiliated.html
+++ b/app/_includes/about-people-affiliated.html
@@ -1,6 +1,6 @@
 {% assign person = include.person %}
 
-  <div class="flex flex-col gap-28 relative py-32 md:py-50" id="{{ person.name | slugify }}">
+  <div class="flex flex-col gap-28 relative py-32 lg:py-50" id="{{ person.name | slugify }}">
     {% if include.border == 'true' %}
       <div class="hidden md:block absolute md:-right-30 lg:-right-60 -top-10 md:top-0 w-1 h-full bg-black"></div>
     {% endif %}
@@ -10,7 +10,7 @@
     {% endif %}
 
     <figure>
-      <img class="w-full relative overflow-hidden rounded-full img-full-width" src=" {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }}"
+      <img class="w-full relative overflow-hidden rounded-full max-w-[75%] m-auto" src=" {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }}"
            srcset=" {{ site.baseurl }}/assets/thumbs/216x216c/{{ person.image }} 216w,
                     {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }} 432w,
                     {{ site.baseurl }}/assets/thumbs/648x648c/{{ person.image }} 648w"

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -53,7 +53,7 @@ layout: default
 
   <section class="container flex flex-col gap-50">
     <h2 class="h2 pb-50">The People at the Lab</h2>
-    <div class="grid md:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-120">
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
       {% assign affiliates = site.data.people | where: "affiliated", true | sort: "sort_name" %}
       {% assign sections = "Faculty Director, Staff" | split: ", " %}
       {% for section in sections %}
@@ -71,7 +71,7 @@ layout: default
     </div>
     <div class="flex flex-col gap-32 pt-50 border-t-1 border-black">
       <h2 class="h2">Fellows</h2>
-      <div class="grid md:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-120">
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
         {% assign fellows = site.data.people | where: "affiliated", true | sort: "sort_name" %}
         {% assign sections = "Fellows" | split: ", " %}
         {% for section in sections %}

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -78,6 +78,10 @@ module.exports = {
             acc[val] = `${val}px`
             return acc
           }, {}),
+      },
+      screens: {
+        'sm': '576px',
+        'md': '992px',
       }
     },
     keyframes: {


### PR DESCRIPTION
See LIL-2562.

On the "About" page, current affiliates' bios and headshots are displayed in a gallery. The design only shows a three-column version. The current implementation flips to a one-column version when there's not enough space for that. At certain viewport sizes, that results in humongous headshots.

This PR adds an intermediate two-column view, and tweaks the site's breakpoints so that the transition happens at a more natural time. It also caps the size of the headshot, so that it will never be more than 75% the width of the viewport (selected relatively arbitrarily).

I think it still doesn't look polished: I'm not sure about the vertical spacing, and I think maybe the headshots are still too big, at some viewport sizes? But I think it gets us closer.

![image](https://github.com/user-attachments/assets/60d06fed-a67e-4722-a42b-297b2a4f898a)
![image](https://github.com/user-attachments/assets/3a4d67fe-be82-43af-8892-cef2e87d36ed)
![image](https://github.com/user-attachments/assets/6b6156e3-b5c0-4ee2-a8cb-28f31b28b801)
![image](https://github.com/user-attachments/assets/08df1f76-17a6-42a7-a2b3-bc146167702d)
![image](https://github.com/user-attachments/assets/916891a4-4398-43e6-a43b-ef92cb584284)
![image](https://github.com/user-attachments/assets/890cf3c2-fcee-4d38-bd67-898eb30639c5)






 

