### PR TITLE
Footer, at intermediate viewport sizes

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,10 +1,10 @@
 <footer aria-label="page footer" class="bg-black text-white pt-60 pb-40">
-  <div class="container flex flex-wrap md:grid md:grid-cols-12 md:gap-x-20 md:gap-y-26">
-    <a href="/" class="block relative w-full max-w-[160px] md:col-span-4 md:max-w-[340px]">
+  <div class="container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
+    <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>
       <span aria-hidden="true">{% include footer-logo.html %}</span>
     </a>
-    <ul class="footer-nav flex-1 text-right md:text-left md:col-span-6 md:col-start-7 md:text-right md:grid md:grid-cols-2 md:gap-x-20 md:gap-y-10 text-28 md:text-50 leading-[120%] md:leading-[100%] font-medium">
+    <ul class="footer-nav flex-1 text-right sm:text-left sm:col-span-6 sm:col-start-7 sm:text-right sm:grid sm:grid-cols-2 sm:gap-x-20 sm:gap-y-10 text-28 md:text-50 leading-[120%] sm:leading-[100%] font-medium">
       <li>
         <a class="interactive-link" href="{{ site.baseurl }}/our-work/">Our Work</a>
       </li>
@@ -24,7 +24,7 @@
           <a class="interactive-link" href="{{ site.baseurl }}/contact/">Contact</a>
       </li>
     </ul>
-    <div class="md:col-span-12 flex items-center justify-end gap-15 w-full self-end pt-32 pb-40 md:pt-0 md:pb-0">
+    <div class="sm:col-span-12 flex items-center justify-end gap-15 w-full self-end pt-32 pb-40 sm:pt-0 sm:pb-0">
       <a href="{{ site.github_url}}" target="_blank">
         <span class="sr-only">LIL on Github</span>
         <span aria-hidden="true">{% include icon-github.html %}</span>
@@ -38,8 +38,8 @@
         <span aria-hidden="true">{% include icon-linkedin.html %}</span>
       </a>
     </div>
-    <div class="w-full flex flex-col md:flex-row md:items-center md:justify-between md:gap-20 pt-24 border-t-1 border-white md:col-span-12 text-12 md:text-16">
-      <div class="flex flex-col md:flex-row md:items-center md:gap-100">
+    <div class="w-full flex flex-col sm:flex-row sm:items-center sm:justify-between sm:gap-20 pt-24 border-t-1 border-white sm:col-span-12 text-12 sm:text-16">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:gap-100">
         <p>&copy;2024 The President and Fellows of Harvard University</p>
       </div>
       <p><a href="https://accessibility.huit.harvard.edu/digital-accessibility-policy">Accessibility</a></p>


### PR DESCRIPTION
See LIL-2557.

This PR takes a swing at fixing the footer at intermediate viewport sizes. It uses the tweaked breakpoints added in https://github.com/harvard-lil/website-static/pull/591.

Here's how it looks...

on a phone
![image](https://github.com/user-attachments/assets/06cc4747-c483-40a8-bdce-75ccdac1817f)

just before the sm breakpoint (wondering if this wants some margins...)
![image](https://github.com/user-attachments/assets/e231296c-9f8c-430f-84ae-e4475c6d72e4)

just after the sm breakpoint
![image](https://github.com/user-attachments/assets/56ec63ae-b14d-4930-ac8d-5c2ed0081341)

midway between sm and md
![image](https://github.com/user-attachments/assets/e8c0b5d3-e42c-49cd-9dd9-2cbd560a5a1c)

just before the md breakpoint
![image](https://github.com/user-attachments/assets/75a8cf54-41a8-4e52-9856-fe0edec6977e)

just after the md breakpoint
![image](https://github.com/user-attachments/assets/294a0887-81cb-4af2-886d-d77e7a05440e)

large
![image](https://github.com/user-attachments/assets/c474f3db-cb10-4c49-b4cd-df16403f6da5)

full size
![image](https://github.com/user-attachments/assets/68855516-74bf-4f1d-a306-d2e57cc82308)

