### PR TITLE
Adjust homepage proportions to be closer to design

### DIFF
--- a/app/_includes/contact-section.html
+++ b/app/_includes/contact-section.html
@@ -1,8 +1,8 @@
-<section class="container pb-100 md:pb-200">
-  <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
+<section class="container pb-72 md:pb-84">
+  <div class="flex flex-col md:grid md:grid-cols-3 gap-6 md:gap-40">
     <h2 class="h2">{{ include.heading }}</h2>
-    <div class="md:col-span-2 body-text flex flex-col gap-50 pt-24 flex flex-col md:grid md:grid-cols-2 gap-24 md:gap-32">
-      <div class="flex flex-col gap-50">
+    <div class="md:col-span-2 body-text flex flex-col pt-24 flex flex-col md:grid md:grid-cols-2 gap-32">
+      <div class="flex flex-col gap-28">
         <div class="label-value">
           <h3 class="label">Email</h3>
           <a href="mailto:{{ site.email }}" class="value interactive-link dark reverse">{{ site.email }}</a>
@@ -17,7 +17,7 @@
           {% include arrow-link.html label="Map" href="https://www.google.com/maps/place/1557+Massachusetts+Ave,+Cambridge,+MA+02138/@42.3782483,-71.1213313,17z/data=!3m1!4b1!4m5!3m4!1s0x89e37741bde17be1:0xf64e9368998f6967!8m2!3d42.3782444!4d-71.1191426" target="_blank" reverse=true %}
         </div>
       </div>
-      <div class="flex flex-col gap-32">
+      <div class="flex flex-col gap-28">
         <div class="label-value">
           <h3 class="label">Newsletter</h3>
           <p class="value max-w-[330px]">

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer aria-label="page footer" class="bg-black text-white pt-60 pb-40">
+<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40">
   <div class="container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -10,7 +10,7 @@
       </a>
     </lil-marquee>
   {% endif %}
-  <header class="pt-32 container">
+  <header class="pt-12 md:pt-36 container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>
       <a href="/" class="logo">

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -4,19 +4,19 @@
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}
-  <div class="{{ include.background }} pt-60 pb-20 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden md:min-h-[550px]">
-    <div class="flex items-start justify-start md:items-center md:justify-center px-28 md:px-0 pb-28 md:pb-0">
+  <div class="{{ include.background }} pt-36 pb-12 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden md:min-h-[550px]">
+    <div class="flex items-start justify-start md:items-center md:justify-center px-28 md:px-0 pb-18 md:pb-0">
       <img class="w-full max-w-[200px] max-h-[140px] md:max-w-[350px] md:max-h-[300px] object-contain object-left md:object-center w-[150px] h-[150px] md:w-[200px] md:h-[200px]" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
     </div>
-    <div class="w-full p-28 md:p-80 flex flex-col gap-18 md:gap-30">
+    <div class="w-full p-28 pt-0 md:p-80 flex flex-col gap-18 md:gap-30">
       <strong class="h2">{{ include.title }}</strong>
       <p class="body-text max-w-[550px]">{{ include.description }}</p>
       <div class="flex flex-col md:flex-row md:items-center gap-18 md:gap-32 pt-10 md:pt-20">
         {% if include.linkOne %}
-          {% include arrow-link.html label=include.linkOneLabel href=include.linkOne target="_blank" %}
+          {% include arrow-link.html label=include.linkOneLabel href=include.linkOne target="_blank" reverse=true %}
         {% endif %}
         {% if include.linkTwo %}
-        {% include arrow-link.html label=include.linkTwoLabel href=include.linkTwo target="_self" %}
+        {% include arrow-link.html label=include.linkTwoLabel href=include.linkTwo target="_self" reverse=true %}
         {% endif %}
       </div>
     </div>

--- a/app/index.html
+++ b/app/index.html
@@ -7,32 +7,45 @@ slug: home
 sharing-card-type: summary_large_image
 ---
 
-<div class="pt-50 pb-40 md:pt-[16vh] md:pb-[26vh] flex items-center justify-center text-[clamp(52px,10vw,150px)] leading-[100%] container">
+<div class="pt-36 pb-32 sm:pt-96 sm:pb-132  md:pt-156 md:pb-228 max-w-[92%] sm:max-w-[88%] xl:max-w-[1190px] m-auto text-[clamp(52px,8.5vw,120px)] leading-[clamp(52px,8.5vw,120px)] sm:text-center">
   <h1>
     <strong>Library Innovation Lab</strong> at <strong>Harvard Law School</strong>
   </h1>
 </div>
 
-<div class="bg-black text-white w-full pt-32 pb-32 md:pt-120 md:pb-160 continer text-center flex flex-col justify-center items-center gap-20 md:gap-32">
+<div class="bg-black text-white w-full py-48 md:pt-72 md:pb-120 continer text-center flex flex-col justify-center items-center gap-20 md:gap-32">
   <div class="font-mono uppercase tracking-8 text-green text-16 md:text-24 font-normal">Our Mission</div>
-  <div contenteditable class="text-28 md:text-54 leading-120 max-w-[1120px] tracking-2">To grow knowledge and community by bringing <strong>library principles to technological frontiers.</strong></div>
+  <div contenteditable class="text-28 md:text-54 leading-120 max-w-[1200px] mx-12">To grow knowledge and community by bringing <strong>library principles</strong> to <strong>technological frontiers.</strong></div>
 </div>
 
 <div class="bg-blue py-32">
-  <div class="container flex flex-col md:flex-row md:items-center md:justify-between gap-16 md:gap-24">
+  <div class="container flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12 md:gap-24">
     <h2 class="text-14 md:text-18 tracking-8 uppercase font-medium">Follow our latest projects</h2>
     <ul class="flex items-center gap-60 text-[24px] leading-[120%]">
       <li>
-        {% include arrow-link.html label="Twitter" href="https://twitter.com" target="_blank" %}
+        {% include arrow-link.html label="Twitter" href="https://twitter.com" target="_blank" reverse=true %}
       </li>
       <li>
-        {% include arrow-link.html label="Newsletter" href="https://ocb.to/lawvocado" target="_blank" %}
+        {% include arrow-link.html label="Newsletter" href="https://ocb.to/lawvocado" target="_blank" reverse=true %}
       </li>
     </ul>
   </div>
 </div>
 
-<div class="flex flex-col gap-50 md:gap-80">
+<div class="container flex flex-col gap-50 md:gap-100">
+  <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48">
+    <h2 class="h2">Who We Are</h2>
+    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-24">
+      <div class="flex flex-col gap-20 max-w-[650px]">
+        <p>The Library Innovation Lab is a team working at the intersection of libraries, technology, and law.</p>
+        <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research to empower more people to access and build our shared knowledge and cultural heritage.</p>
+      </div>
+      {% include arrow-link.html label="Learn More About Who We Are" href="/about/" reverse=true %}
+    </div>
+  </div>
+</div>
+
+<div class="flex flex-col gap-50 md:gap-60 -mt-12 sm:mt-0 md:-mt-28">
   {% assign featured_projects = site.our_work | where:"featured",true | sort: "order" %}
   <div class="flex flex-col">
     {% for project in featured_projects %}
@@ -58,24 +71,14 @@ sharing-card-type: summary_large_image
   </div>
 
   <div class="container flex flex-col gap-50 md:gap-100">
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 pb-50 md:pb-120 border-b-1 border-black">
-      <h2 class="h2">Who We Are</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-24">
-        <div class="flex flex-col gap-20 max-w-[650px]">
-          <p>The Library Innovation Lab is a team working at the intersection of libraries, technology, and law.</p>
-          <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research to empower more people to access and build our shared knowledge and cultural heritage.</p>
-        </div>
-        {% include arrow-link.html label="Learn More About Who We Are" href="/about/" %}
-      </div>
-    </div>
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-32 md:gap-40 pb-50 md:pb-120 border-b-1 border-black">
+    <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black">
       <h2 class="h2">Our Work</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-50 pt-24">
+      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
         <div class="flex flex-col gap-20 max-w-[650px]">
           <p>We build and explore new technology through the lens of library principles.</p>
           <p>Conducting research to further our understanding of certain technologies allows us to share our knowledge with those in the library field, or those in industry interested in making their tech more private, secure, or focused on the long term.</p>
         </div>
-        {% include arrow-link.html label="View All Projects" href="/our-work/" %}
+        {% include arrow-link.html label="View All Projects" href="/our-work/" reverse=true %}
       </div>
     </div>
   </div>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -80,8 +80,9 @@ module.exports = {
           }, {}),
       },
       screens: {
-        'sm': '576px',
+        'sm': '586px',
         'md': '992px',
+        'xl': '1300px'
       }
     },
     keyframes: {


### PR DESCRIPTION
Today, I lavished the homepage with attention. I went back to the Figma files and closely studied how elements were sized and spaced relative to each other. I then set my viewport to 1440px (the "desktop" size in the design) and tried to get things to match as closely as possible. I then did the same thing at 375px (the "mobile" size in the design). Then, I either tried to translate those "absolute" spacings/sizes to relative ones, so they would look good at all viewport sizes, or, using the responsive mode of my browser's dev tools, advanced pixel by pixel to find the viewport sizes at which things "broke" visually, and then adding intermediate values using breakpoints.

It's hard to show before/after with screenshots, but I gave it a go. If helpful, here are full-page before/after screenshots: [before-after.zip](https://github.com/user-attachments/files/16999807/before-after.zip). But I think the effects of this PR are best experienced in-browser, using your browser's dev tools responsive mode.

The most noticeable change: "Library Innovation Lab at Harvard Law School" should now never wrap to three lines, except on mobile, and is capped at a slightly smaller size. (As implemented, it was capped at 150px, which is larger than specified in the design for 1440px viewports.)

Some things are still broken. 

Vertical spacing is still a little off (though I think this is much closer).

The vertical alignment of left-column headings with right-column text is still irregular. And, featured project cards are still broken at some intermediate viewport sizes:

![image](https://github.com/user-attachments/assets/040ba818-ad60-4b34-9589-5ee47afad4d1)
 

