### PR TITLE
Handle containers on viewports larger than 1520px.

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40">
-  <div class="container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
+  <div class="nav-container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>
       <span aria-hidden="true">{% include footer-logo.html %}</span>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -10,7 +10,7 @@
       </a>
     </lil-marquee>
   {% endif %}
-  <header class="pt-12 md:pt-36 container">
+  <header class="pt-12 md:pt-36 nav-container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>
       <a href="/" class="logo">

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -56,7 +56,7 @@ html {
   scrollbar-gutter: stable;
 }
 
-.container {
+.nav-container {
   padding-inline: 40px;
   width: 100%;
   max-width: 1600px;
@@ -64,8 +64,27 @@ html {
 }
 
 @media only screen and (max-width: 768px) {
-  .container {
+  .nav-container {
     padding-inline: 20px;
+  }
+}
+
+.container {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: 20px;
+}
+
+@media only screen and (min-width: 586px) {
+  .container {
+    max-width: calc(100vw - 80px);
+    padding-inline: 0;
+  }
+}
+
+@media only screen and (min-width: 1521px) {
+  .container {
+    max-width: 1440px;
   }
 }
 

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -82,7 +82,8 @@ module.exports = {
       screens: {
         'sm': '586px',
         'md': '992px',
-        'xl': '1300px'
+        'xl': '1300px',
+        '2xl': '1520px'
       }
     },
     keyframes: {


### PR DESCRIPTION
The design calls for 40px of gutter around containers at a 1440px viewport. The current implementation uses padding to achieve that.

![image](https://github.com/user-attachments/assets/11556e2d-f20a-4bfc-8694-db2c119bd77e)

The design does not specify how to handle even larger viewports. The current implementation caps container width at 1600px (not sure why that number), and calls for a redundant 40px of additional padding.

![image](https://github.com/user-attachments/assets/6f02cea2-4c63-4514-9bfa-726bc74207b4)

This PR tweaks that, so that on especially wide viewport sizes, containers remain at their 1440px widths, for subtly more breathing room.

![image](https://github.com/user-attachments/assets/05569fad-dd00-4d46-90fe-9dc6e309622c)
