### PR TITLE
Containers must be blocks.

### DIFF
--- a/app/about/index.html
+++ b/app/about/index.html
@@ -31,7 +31,7 @@ layout: default
             alt=""
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
-      <figcaption class="inline-block container text-16 py-8">
+      <figcaption class="block container text-16 py-8">
         <strong>Credit: Bob O’Connor</strong> With a focus on fostering collaboration and community, the modernist building has been transformed into a 21st-century work environment.
       </figcaption>
     </figure>

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -22,7 +22,7 @@ layout: default
             alt=""
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
-      <figcaption class="inline-block container text-16 py-8">
+      <figcaption class="block container text-16 py-8">
         <strong>Credit: Bob O’Connor</strong>
       </figcaption>
     </figure>


### PR DESCRIPTION
Quick bug: I noticed that the `.container` CSS wasn't actually getting applied to captions, because those captions were marked up as `display: inline-block`, and container CSS only applies to actual `display: block` elements.