### PR TITLE
Adjust project cards

### DIFF
--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -6,7 +6,7 @@
   {% endif %}
   <div class="{{ include.background }} pt-36 pb-12 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden md:min-h-[550px]">
     <div class="flex items-start justify-start md:items-center md:justify-center px-28 md:px-0 pb-18 md:pb-0">
-      <img class="w-full max-w-[200px] max-h-[140px] md:max-w-[350px] md:max-h-[300px] object-contain object-left md:object-center w-[150px] h-[150px] md:w-[200px] md:h-[200px]" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
+      <img class="w-full max-w-[200px] min-h-[140px] max-h-[140px] md:max-w-[350px] md:max-h-[300px] object-contain object-left md:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
     </div>
     <div class="w-full p-28 pt-0 md:p-80 flex flex-col gap-18 md:gap-30">
       <strong class="h2">{{ include.title }}</strong>

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -4,7 +4,7 @@
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}
-  <div class="{{ include.background }} pt-36 pb-12 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden md:min-h-[550px]">
+  <div class="{{ include.background }} pt-36 pb-12 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden">
     <div class="flex items-start justify-start md:items-center md:justify-center px-28 md:px-0 pb-18 md:pb-0">
       <img class="w-full max-w-[200px] min-h-[140px] max-h-[140px] md:max-w-[350px] md:max-h-[300px] object-contain object-left md:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
     </div>

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -1,26 +1,26 @@
-<div class="relative block container {% if include.featured %}pt-80 md:pt-120{% endif %}">
+<div class="relative block container {% if include.featured %}pt-80 tbl:pt-120{% endif %}">
   {% if include.featured %}
-    <div class="absolute w-72 h-72 md:w-165 md:h-165 top-45 left-24 md:top-40 md:left-50 z-[2] motion-safe:animate-spin">
+    <div class="absolute w-72 h-72 tbl:w-165 tbl:h-165 top-45 left-24 tbl:top-40 tbl:left-50 z-[2] motion-safe:animate-spin">
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}
-  <div class="{{ include.background }} pt-36 pb-12 md:pt-0 md:pb-0 flex flex-col md:grid md:grid-cols-2 md:items-center relative overflow-hidden">
-    <div class="flex items-start justify-start md:items-center md:justify-center px-28 md:px-0 pb-18 md:pb-0">
-      <img class="w-full max-w-[200px] min-h-[140px] max-h-[140px] md:max-w-[350px] md:max-h-[300px] object-contain object-left md:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
+  <div class="{{ include.background }} pt-36 pb-12 tbl:pt-0 tbl:pb-0 flex flex-col tbl:grid tbl:grid-cols-2 tbl:items-center relative overflow-hidden">
+    <div class="flex items-start justify-start tbl:items-center tbl:justify-center px-28 tbl:px-0">
+      <img class="w-full max-w-[135px] min-h-[140px] max-h-[140px] tbl:max-w-[350px] tbl:max-h-[300px] object-contain object-left tbl:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
     </div>
-    <div class="w-full p-28 pt-0 md:p-80 flex flex-col gap-18 md:gap-30">
+    <div class="w-full p-28 pt-0 tbl:p-80 flex flex-col gap-18 tbl:gap-30">
       <strong class="h2">{{ include.title }}</strong>
-      <p class="body-text max-w-[550px]">{{ include.description }}</p>
-      <div class="flex flex-col md:flex-row md:items-center gap-18 md:gap-32 pt-10 md:pt-20">
+      <p class="body-text">{{ include.description }}</p>
+      <div class="flex flex-col tbl:flex-row tbl:items-center gap-18 tbl:gap-32 pt-10 tbl:pt-20 whitespace-nowrap">
         {% if include.linkOne %}
-          {% include arrow-link.html label=include.linkOneLabel href=include.linkOne target="_blank" reverse=true %}
+          <span>{% include arrow-link-inline.html label=include.linkOneLabel href=include.linkOne target="_blank" reverse=true %}</span>
         {% endif %}
         {% if include.linkTwo %}
-        {% include arrow-link.html label=include.linkTwoLabel href=include.linkTwo target="_self" reverse=true %}
+          <span>{% include arrow-link-inline.html label=include.linkTwoLabel href=include.linkTwo target="_self" reverse=true %}</span>
         {% endif %}
       </div>
     </div>
-    <div aria-hidden="true" class="absolute w-[150px] h-[150px] bg-white top-0 left-0 rotate-45 -translate-y-[75%] -translate-x-[75%] md:-translate-y-[60%] md:-translate-x-[60%]"></div>
-    <div aria-hidden="true" class="absolute w-[150px] h-[150px] bg-white bottom-0 right-0 rotate-45 translate-x-[75%] translate-y-[75%] md:translate-y-[60%] md:translate-x-[60%]"></div>
+    <div aria-hidden="true" class="absolute w-[150px] h-[150px] bg-white top-0 left-0 rotate-45 -translate-y-[75%] -translate-x-[75%] tbl:-translate-y-[60%] tbl:-translate-x-[60%]"></div>
+    <div aria-hidden="true" class="absolute w-[150px] h-[150px] bg-white bottom-0 right-0 rotate-45 translate-x-[75%] translate-y-[75%] tbl:translate-y-[60%] tbl:translate-x-[60%]"></div>
   </div>
 </div>

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -1,17 +1,17 @@
-<div class="relative block container {% if include.featured %}pt-80 tbl:pt-120{% endif %}">
+<div class="relative block container {% if include.featured %}pt-84 tbl:pt-120{% endif %}">
   {% if include.featured %}
-    <div class="absolute w-72 h-72 tbl:w-165 tbl:h-165 top-45 left-24 tbl:top-40 tbl:left-50 z-[2] motion-safe:animate-spin">
+    <div class="absolute w-72 h-72 tbl:w-165 tbl:h-165 top-48 left-12 sm:left-0 tbl:top-36 z-[2] motion-safe:animate-spin">
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}
   <div class="{{ include.background }} pt-36 pb-12 tbl:pt-0 tbl:pb-0 flex flex-col tbl:grid tbl:grid-cols-2 tbl:items-center relative overflow-hidden">
-    <div class="flex items-start justify-start tbl:items-center tbl:justify-center px-28 tbl:px-0">
-      <img class="w-full max-w-[135px] min-h-[140px] max-h-[140px] tbl:max-w-[350px] tbl:max-h-[300px] object-contain object-left tbl:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
+    <div class="flex items-start justify-start tbl:items-center tbl:justify-center px-24 tbl:px-0">
+      <img class="w-full max-w-[132px] min-h-[132px] max-h-[132px] pb-12 tbl:max-w-[348px] tbl:max-h-[300px] tbl:pb-0 object-contain object-left tbl:object-center" src="{{ site.baseurl }}/assets/images/{{ include.logo }}" alt="{{ include.title }}">
     </div>
-    <div class="w-full p-28 pt-0 tbl:p-80 flex flex-col gap-18 tbl:gap-30">
+    <div class="w-full p-24 pt-0 tbl:p-72 flex flex-col gap-18 tbl:gap-32">
       <strong class="h2">{{ include.title }}</strong>
       <p class="body-text">{{ include.description }}</p>
-      <div class="flex flex-col tbl:flex-row tbl:items-center gap-18 tbl:gap-32 pt-10 tbl:pt-20 whitespace-nowrap">
+      <div class="flex flex-col tbl:flex-row tbl:items-center gap-18 tbl:gap-32 pt-12 tbl:pt-24 whitespace-nowrap">
         {% if include.linkOne %}
           <span>{% include arrow-link-inline.html label=include.linkOneLabel href=include.linkOne target="_blank" reverse=true %}</span>
         {% endif %}

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -1,6 +1,6 @@
 <div class="relative block container {% if include.featured %}pt-84 tbl:pt-120{% endif %}">
   {% if include.featured %}
-    <div class="absolute w-72 h-72 tbl:w-165 tbl:h-165 top-48 left-12 sm:left-0 tbl:top-36 z-[2] motion-safe:animate-spin">
+    <div class="absolute w-72 h-72 tbl:w-136 tbl:h-136 md:w-165 md:h-165 top-48 left-12 sm:left-0 tbl:top-52 md:top-36 z-[2] motion-safe:animate-spin">
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}

--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -1,6 +1,6 @@
-<div class="relative block container {% if include.featured %}pt-84 tbl:pt-120{% endif %}">
+<div class="relative block container {% if include.featured %}pt-84 tbl:pt-120 md:pt-84{% endif %}">
   {% if include.featured %}
-    <div class="absolute w-72 h-72 tbl:w-136 tbl:h-136 md:w-165 md:h-165 top-48 left-12 sm:left-0 tbl:top-52 md:top-36 z-[2] motion-safe:animate-spin">
+    <div class="absolute w-72 h-72 tbl:w-136 tbl:h-136 md:w-165 md:h-165 top-48 left-12 sm:left-0 tbl:top-52 md:top-0 z-[2] motion-safe:animate-spin">
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -459,7 +459,7 @@ html.is-animating .transition-main {
   opacity: 0;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 859px) {
   .page-hero {
     padding-bottom: 40px;
     margin-bottom: 40px;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -77,6 +77,13 @@ html {
 
 @media only screen and (min-width: 586px) {
   .container {
+    max-width: min(60ch, 100vw - 80px);
+    padding-inline: 0;
+  }
+}
+
+@media only screen and (min-width: 860px) {
+  .container {
     max-width: calc(100vw - 80px);
     padding-inline: 0;
   }

--- a/app/index.html
+++ b/app/index.html
@@ -36,7 +36,7 @@ sharing-card-type: summary_large_image
   <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48">
     <h2 class="h2">Who We Are</h2>
     <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-24">
-      <div class="flex flex-col gap-20 max-w-[650px]">
+      <div class="flex flex-col gap-20">
         <p>The Library Innovation Lab is a team working at the intersection of libraries, technology, and law.</p>
         <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research to empower more people to access and build our shared knowledge and cultural heritage.</p>
       </div>
@@ -74,7 +74,7 @@ sharing-card-type: summary_large_image
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black">
       <h2 class="h2">Our Work</h2>
       <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
-        <div class="flex flex-col gap-20 max-w-[650px]">
+        <div class="flex flex-col gap-20">
           <p>We build and explore new technology through the lens of library principles.</p>
           <p>Conducting research to further our understanding of certain technologies allows us to share our knowledge with those in the library field, or those in industry interested in making their tech more private, secure, or focused on the long term.</p>
         </div>

--- a/app/index.html
+++ b/app/index.html
@@ -45,7 +45,7 @@ sharing-card-type: summary_large_image
   </div>
 </div>
 
-<div class="flex flex-col gap-50 md:gap-60 -mt-12 sm:mt-0 md:-mt-28">
+<div class="flex flex-col gap-50 md:gap-60 -mt-12 sm:mt-0 md:-mt-18">
   {% assign featured_projects = site.our_work | where:"featured",true | sort: "order" %}
   <div class="flex flex-col">
     {% for project in featured_projects %}

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -52,6 +52,14 @@ module.exports = {
       140: '140%',
       150: '150%',
     },
+    screens: {
+      'sm': '586px',
+      'tbl': '860px',
+      'md': '992px',
+      'lg': '1030px',
+      'xl': '1300px',
+      '2xl': '1520px'
+    },
     extend: {
       fontSize: {
         ...new Array(401)
@@ -78,12 +86,6 @@ module.exports = {
             acc[val] = `${val}px`
             return acc
           }, {}),
-      },
-      screens: {
-        'sm': '586px',
-        'md': '992px',
-        'xl': '1300px',
-        '2xl': '1520px'
       }
     },
     keyframes: {


### PR DESCRIPTION
In the design, the spacing of project cards is tighter, and logo sizes are different. This PR tweaks proportions accordingly.

The cards were also broken at intermediate viewport sizes: the links wrapped, the underline didn't, etc.

I ended up adding an additional CSS breakpoint, arbitrarily named `tbl`, to give us more control.

We can still get into situations where elements that look great on mobile... stretch too wide before snapping to tablet... so I, just as a quick fix, set the size of containers to be responsive, for small tablet / large mobile sizes, instead of keeping a fixed margin of 20px/40px. We could revisit that, and switch to responsive font sizes with clamp, if we have the energy, instead. 