### PR TITLE
Remove extra borders.

### DIFF
--- a/app/_includes/about-people-unaffiliated.html
+++ b/app/_includes/about-people-unaffiliated.html
@@ -1,6 +1,6 @@
 {% assign person = include.person %}
 
-<div class="body-text w-full py-32 border-t-1 border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative" id="{{ person.name | slugify }}">
+<div class="body-text w-full py-32 {% unless forloop.first %}border-t-1{% endunless %} border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative" id="{{ person.name | slugify }}">
   <div class="label md:col-span-3">{{person.name}}</div>
   <div class="md:col-span-6">{{person.role}}</div>
   <div class="pt-20 md:pt-0 md:col-span-3 flex md:justify-end">

--- a/app/events.html
+++ b/app/events.html
@@ -83,7 +83,7 @@ layout: default
           {% capture linkLabel %}
             <span class="sr-only"> {{ event.title }},</span> More Info
           {% endcapture %}
-          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
             <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
             <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -114,7 +114,7 @@ layout: default
         {% assign retired_projects_without_pages = site.our_work_pageless | where:"retired",true %}
         {% assign retired_projects = retired_projects_with_pages | concat: retired_projects_without_pages | sort: "retired_date" | reverse %}
         {% for project in retired_projects %}
-          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
             <h3 class="label col-span-3">{{ project.title }}</h3>
             <span class="col-span-6">{{ project.what_does_it_do }}</span>
             {% if project.collection == 'our_work' %}


### PR DESCRIPTION
Lists of events, etc. aren't supposed to have borders on the top or on the bottom. This PR removes the extra ones.

Note that the design has borders on top and bottom for the News list on projects' pages. I plan to confirm that design is intentionally different.