### PR TITLE
Remove top and bottom borders from news list.

### DIFF
--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -52,7 +52,7 @@ layout: default
       <h2 class="h2">News</h2>
       <div class="flex flex-col items-start w-full">
         {% for article in news %}
-          <div class="body-text w-full py-32 border-t-1 border-black last-of-type:border-b-1 flex grid grid-cols-12 gap-24 relative">
+          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
             <!-- format date as 02.12.24 -->
             <span class="label col-span-3">
               <span class="align-middle">{{ article.date | date: "%m/%d/%y" }}</span>


### PR DESCRIPTION
When removing the top and bottom borders from [other lists](https://github.com/harvard-lil/website-static/pull/600), to make them match the design, I noticed that the news list on particular project pages was designed differently, and included a top and bottom border.

We asked Jacob about it, and he said he'd prefer to remain consistent, so: this PR removes those borders.

It does not adjust the vertical spacing, because we're probably going to make sweeping changes there.