### PR TITLE
Fallback for 404ing blog post thumbnails

### DIFF
--- a/app/_includes/post-card.html
+++ b/app/_includes/post-card.html
@@ -10,16 +10,17 @@
   {% endif %}
 {% endif %}
 
+<!-- NB: this HTML is not used when rendering search results. That markup is in a string in main.js  -->
 <article itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-14 relative">
   <header class="aspect-square w-full bg-gray relative">
-    {% if first_img_src != '' %}
-      <img src="{{ first_img_src }}" class="w-full h-full object-cover absolute inset-0" alt="{{ post.title | smartify }}" />
+    {% if include.post.thumbnail %}
+      <img src="{{ include.post.thumbnail }}" class="w-full h-full object-cover absolute inset-0" alt="" />
+    {% elsif first_img_src != '' %}
+      <object data="{{ first_img_src }}" class="w-full h-full object-cover absolute inset-0">
+        <img src="{{ site.baseurl }}/assets/images/blog-thumbnail-{{ include.thumb_index }}.png" class="w-full h-full object-cover absolute inset-0" alt="" />
+      </object>
     {% else %}
-      {% if include.post.thumbnail %}
-        <img src="{{ include.post.thumbnail }}" class="w-full h-full object-cover absolute inset-0" alt="{{ post.title | smartify }}" />
-      {% else %}
-        <img src="{{ site.baseurl }}/assets/images/blog-thumbnail-{{ include.thumb_index }}.png" class="w-full h-full object-cover absolute inset-0" alt="{{ post.title | smartify }}" />
-      {% endif %}
+      <img src="{{ site.baseurl }}/assets/images/blog-thumbnail-{{ include.thumb_index }}.png" class="w-full h-full object-cover absolute inset-0" alt="" />
     {% endif %}
   </header>
   <div class="flex flex-col gap-8">

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -21,10 +21,14 @@ function safeDuration(duration) {
     return prefersReducedMotion() ? 0 : duration;
 }
 
-function getRandomInt(min, max) {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min + 1)) + min;
+function createCycler(min, max) {
+    let current = min;
+
+    return function() {
+        const returnValue = current; // Store the current value to return
+        current = current < max ? current + 1 : 1; // Cycle through 1-6
+        return returnValue; // Return the current value
+    };
 }
 
 /*
@@ -59,13 +63,14 @@ class jekyllSearch {
   
     async displayResults() {
       const results = await this.findResults()
+      const cycler = createCycler(1,6);
       const html = results.map(item => {
         return `
           <article class="flex flex-col gap-8 relative">
             <header class="aspect-square w-full bg-gray relative">
               ${item.image && item.image !== null && item.image !== '' ? (
                 `<object data="${item.image}" class="w-full h-full object-cover absolute inset-0">
-                    <img src="/assets/images/blog-thumbnail-${getRandomInt(1,6)}.png" class="w-full h-full object-cover absolute inset-0" alt="" />
+                    <img src="/assets/images/blog-thumbnail-${cycler()}.png" class="w-full h-full object-cover absolute inset-0" alt="" />
                  </object>`
               ) : ''}
             </header>

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -21,6 +21,12 @@ function safeDuration(duration) {
     return prefersReducedMotion() ? 0 : duration;
 }
 
+function getRandomInt(min, max) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 /*
 * https://github.com/daviddarnes/jekyll-search-js
 */
@@ -58,7 +64,9 @@ class jekyllSearch {
           <article class="flex flex-col gap-8 relative">
             <header class="aspect-square w-full bg-gray relative">
               ${item.image && item.image !== null && item.image !== '' ? (
-                `<img src="${item.image}" class="w-full h-full object-cover absolute inset-0" alt="${item.title}" />`
+                `<object data="${item.image}" class="w-full h-full object-cover absolute inset-0">
+                    <img src="/assets/images/blog-thumbnail-${getRandomInt(1,6)}.png" class="w-full h-full object-cover absolute inset-0" alt="" />
+                 </object>`
               ) : ''}
             </header>
             <h2 class="text-18 leading-115 font-medium" itemprop="headline">


### PR DESCRIPTION
In this design, the list of blog posts is a series of labeled images. The logic is supposed to be as follows:

- if a post defines a special thumbnail, use that
- if not, and if a post contains one or more images, use the first image in the post
- if not, use one of the fallback images

This PR fixes that: as is, the special thumbnail is overridden by a first image.

And, it adds special handling for when the first image 404s using [this strategy](https://stackoverflow.com/questions/980855/inputting-a-default-image-in-case-the-src-attribute-of-an-html-img-is-not-vali), which I hadn't seen before.

I note you have to do this in two spots: the HTML include used by Jekyll.... and the javascript file used to render search results.

Before:
![image](https://github.com/user-attachments/assets/7abc67a5-4531-4e94-8ffc-1b51a200c96e)

After:
![image](https://github.com/user-attachments/assets/6b164e8e-336f-4d92-8a01-a754d1ab38b5)
