### PR TITLE
Add apostrophe to tag.

### DIFF
--- a/app/_config.yml
+++ b/app/_config.yml
@@ -161,7 +161,7 @@ autopages:
     # the pagination permalink path is then appended to this permalink structure
     permalink: '/blog/category/:cat/'
     slugify:
-      mode: raw
+      mode: default
       cased: true
 
   collections:
@@ -174,5 +174,5 @@ autopages:
     title: 'Posts tagged ":tag" | Blog' # :tag is replaced by the tag name
     permalink: '/blog/tag/:tag/'
     slugify:
-      mode: raw
+      mode: default
       cased: true

--- a/app/_data/featured_tags.yaml
+++ b/app/_data/featured_tags.yaml
@@ -1,4 +1,4 @@
 - AI Research
 - Tools
 - Library Principles
-- Fellows Research
+- Fellows' Research

--- a/app/_data/featured_tags.yaml
+++ b/app/_data/featured_tags.yaml
@@ -1,4 +1,4 @@
 - AI Research
 - Tools
 - Library Principles
-- Fellows' Research
+- Fellows’ Research

--- a/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
+++ b/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
@@ -11,7 +11,7 @@ tags:
 - link rot
 - million dollar homepage
 - perma
-- Fellows' Research
+- Fellows’ Research
 ---
 
 In 2005, British student Alex Tew had a million-dollar idea. He launched [www.MillionDollarHomepage.com](http://www.milliondollarhomepage.com/), a website that presented initial visitors with nothing but a 1000×1000 canvas of blank pixels. At the cost of $1/pixel, visitors could permanently claim 10×10 blocks of pixels and populate them however they’d like. Pixel blocks could also be embedded with URLs and tooltip text of the buyer’s choosing.

--- a/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
+++ b/app/_posts/2017-07-21-a-million-squandered-the-million-dollar-homepage-as-a-decaying-digital-artifact.md
@@ -11,7 +11,7 @@ tags:
 - link rot
 - million dollar homepage
 - perma
-- Fellows Research
+- Fellows' Research
 ---
 
 In 2005, British student Alex Tew had a million-dollar idea. He launched [www.MillionDollarHomepage.com](http://www.milliondollarhomepage.com/), a website that presented initial visitors with nothing but a 1000×1000 canvas of blank pixels. At the cost of $1/pixel, visitors could permanently claim 10×10 blocks of pixels and populate them however they’d like. Pixel blocks could also be embedded with URLs and tooltip text of the buyer’s choosing.

--- a/app/_posts/2019-09-17-nelson-guest.md
+++ b/app/_posts/2019-09-17-nelson-guest.md
@@ -2,7 +2,7 @@
 title: "Guest Post: Do Elected and Appointed Judges Write Opinions Differently?"
 guest-author: "Michael Nelson and Steven Morgan"
 tags:
-- Fellows Research
+- Fellows' Research
 ---
 [Unlike anywhere else in the world](https://www.jstor.org/stable/10.1086/679017), most judges in the United States today are elected. But it hasn’t always been this way. [Over the past two centuries](https://www.jstor.org/stable/40648483?seq=1#metadata_info_tab_contents), the American states have taken a variety of different paths, alternating through a variety of elective and appointive methods.  [Opponents](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1337&context=facpub) of judicial elections charge that these institutions detract from judicial independence, harm the legitimacy of the judiciary, and put unqualified jurists on the bench; [those](https://www.amazon.com/Elections-Controversies-Electoral-Democracy-Representation/dp/0415991331) who support judicial elections counter that, by publicly involving the American people in the process of judicial selection, judicial elections can enhance judicial legitimacy. To say this has been an intense debate of academic, political, and popular interest is an [understatement](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1052&context=facpub).
 

--- a/app/_posts/2019-09-17-nelson-guest.md
+++ b/app/_posts/2019-09-17-nelson-guest.md
@@ -2,7 +2,7 @@
 title: "Guest Post: Do Elected and Appointed Judges Write Opinions Differently?"
 guest-author: "Michael Nelson and Steven Morgan"
 tags:
-- Fellows' Research
+- Fellows’ Research
 ---
 [Unlike anywhere else in the world](https://www.jstor.org/stable/10.1086/679017), most judges in the United States today are elected. But it hasn’t always been this way. [Over the past two centuries](https://www.jstor.org/stable/40648483?seq=1#metadata_info_tab_contents), the American states have taken a variety of different paths, alternating through a variety of elective and appointive methods.  [Opponents](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1337&context=facpub) of judicial elections charge that these institutions detract from judicial independence, harm the legitimacy of the judiciary, and put unqualified jurists on the bench; [those](https://www.amazon.com/Elections-Controversies-Electoral-Democracy-Representation/dp/0415991331) who support judicial elections counter that, by publicly involving the American people in the process of judicial selection, judicial elections can enhance judicial legitimacy. To say this has been an intense debate of academic, political, and popular interest is an [understatement](https://www.repository.law.indiana.edu/cgi/viewcontent.cgi?article=1052&context=facpub).
 

--- a/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
+++ b/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
@@ -3,7 +3,7 @@ title: "Guest Post: Is the US Supreme Court in lockstep with Congress when it co
 guest-author: "Abdul Abdulrahim"
 excerpt_separator: <!--more-->
 tags:
-- Fellows Research
+- Fellows' Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
+++ b/app/_posts/2019-11-14-guest-post-is-the-us-supreme-court-in-lockstep-with-congress-when-it-comes-to-abortion.md
@@ -3,7 +3,7 @@ title: "Guest Post: Is the US Supreme Court in lockstep with Congress when it co
 guest-author: "Abdul Abdulrahim"
 excerpt_separator: <!--more-->
 tags:
-- Fellows' Research
+- Fellows’ Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
+++ b/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
@@ -3,7 +3,7 @@ title: 'Guest Post: An Empirical Study of Statutory Interpretation in Tax Law'
 guest-author: Jonathan H. Choi
 excerpt_separator: <!--more-->
 tags:
-- Fellows Research
+- Fellows' Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
+++ b/app/_posts/2020-06-01-guest-post-an-empirical-study-of-statutory-interpretation-in-tax-law.md
@@ -3,7 +3,7 @@ title: 'Guest Post: An Empirical Study of Statutory Interpretation in Tax Law'
 guest-author: Jonathan H. Choi
 excerpt_separator: <!--more-->
 tags:
-- Fellows' Research
+- Fellows’ Research
 ---
 *This guest post is part of the CAP Research Community Series. This series highlights research, applications, and projects created with Caselaw Access Project data.*
 

--- a/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
+++ b/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
@@ -3,7 +3,7 @@ title: Interface Upgrade | Integrating Queries into Search and Case View
 author: andy-gu
 date: 2021-11-10 02:00:00+00:00
 tags:
-- Fellows' Research
+- Fellows’ Research
 ---
 With expanded feature capabilities, users may find writing these queries to be more difficult, especially as researchers increase the complexity of their investigations. To make usage easier, we have integrated the [Trends](https://case.law/trends/) query language into the [Search](https://case.law/search/) and [Case View](https://cite.case.law/) features. From a search query, users can click the Trends button, upon which our servers will automatically convert an existing query into a Trends timeline.
 

--- a/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
+++ b/app/_posts/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
@@ -3,7 +3,7 @@ title: Interface Upgrade | Integrating Queries into Search and Case View
 author: andy-gu
 date: 2021-11-10 02:00:00+00:00
 tags:
-- Fellows Research
+- Fellows' Research
 ---
 With expanded feature capabilities, users may find writing these queries to be more difficult, especially as researchers increase the complexity of their investigations. To make usage easier, we have integrated the [Trends](https://case.law/trends/) query language into the [Search](https://case.law/search/) and [Case View](https://cite.case.law/) features. From a search query, users can click the Trends button, upon which our servers will automatically convert an existing query into a Trends timeline.
 

--- a/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
+++ b/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
@@ -4,7 +4,7 @@ author: liza-daly
 excerpt_separator: <!--more-->
 tags:
 - Library Principles
-- Fellows Research
+- Fellows' Research
 ---
 I started with the idea of a computer-generated story in which audience participation creates copies of the narrative from each person’s point of view. The story would evolve in real time as new users joined and each person’s copy would update accordingly. I called the story *Forks*. After some initial trials, I decided not to launch it because I did not believe the project was securable against harm.
 

--- a/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
+++ b/app/_posts/2022-12-07-ethical-collaborative-storytelling.md
@@ -4,7 +4,7 @@ author: liza-daly
 excerpt_separator: <!--more-->
 tags:
 - Library Principles
-- Fellows' Research
+- Fellows’ Research
 ---
 I started with the idea of a computer-generated story in which audience participation creates copies of the narrative from each person’s point of view. The story would evolve in real time as new users joined and each person’s copy would update accordingly. I called the story *Forks*. After some initial trials, I decided not to launch it because I did not believe the project was securable against harm.
 

--- a/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
+++ b/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
@@ -5,7 +5,7 @@ excerpt_separator: <!--more-->
 sharing-image: images/perma-cost.png
 tags:
 - Library Principles
-- Fellows' Research
+- Fellows’ Research
 ---
 At LIL, we’ve been providing users with the ability to preserve online sources via [Perma.cc](https://perma.cc/about) since 2013. Running a digital archive puts us in the “forever business”–what’s online today may be gone tomorrow, but that Perma Link you saved should never expire. Promising to host something forever brings with it different challenges than hosting something for a month or a year. There are the technical burdens: How will we guarantee these links stay accessible even as the underlying technologies continue to develop? There are logistical concerns: Where will we put all these files? There’s also a question of cost: Just how much does it cost to store a file forever?
 

--- a/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
+++ b/app/_posts/2024-02-08-the-cost-of-a-digital-archive.md
@@ -5,7 +5,7 @@ excerpt_separator: <!--more-->
 sharing-image: images/perma-cost.png
 tags:
 - Library Principles
-- Fellows Research
+- Fellows' Research
 ---
 At LIL, we’ve been providing users with the ability to preserve online sources via [Perma.cc](https://perma.cc/about) since 2013. Running a digital archive puts us in the “forever business”–what’s online today may be gone tomorrow, but that Perma Link you saved should never expire. Promising to host something forever brings with it different challenges than hosting something for a month or a year. There are the technical burdens: How will we guarantee these links stay accessible even as the underlying technologies continue to develop? There are logistical concerns: Where will we put all these files? There’s also a question of cost: Just how much does it cost to store a file forever?
 

--- a/app/_posts/2024-02-29-the-cloud.md
+++ b/app/_posts/2024-02-29-the-cloud.md
@@ -5,7 +5,7 @@ excerpt_separator: <!--more-->
 sharing-image: images/exploding-cloud.png
 tags:
 - Library Principles
-- Fellows Research
+- Fellows' Research
 ---
 
 <img src="https://lil-blog-media.s3.amazonaws.com/exploding-cloud.webp" alt="The moment the cloud explodes"/>

--- a/app/_posts/2024-02-29-the-cloud.md
+++ b/app/_posts/2024-02-29-the-cloud.md
@@ -5,7 +5,7 @@ excerpt_separator: <!--more-->
 sharing-image: images/exploding-cloud.png
 tags:
 - Library Principles
-- Fellows' Research
+- Fellows’ Research
 ---
 
 <img src="https://lil-blog-media.s3.amazonaws.com/exploding-cloud.webp" alt="The moment the cloud explodes"/>


### PR DESCRIPTION
This PR adds an apostrophe to the featured tag.

I updated the slugifying strategy, so that the apostrophe does not appear in the URL. (See [these options](https://github.com/jekyll/jekyll/blob/4d96e4b7bde82c3d68510828152b81a5d679a2bf/lib/jekyll/utils.rb#L15-L18)). Reviewing the list of other tags (including those not currently linked on the site), I did not see that this causes the URLs associated with any other tags to change.