### PR TITLE
Standardize space between footer and content.

### DIFF
--- a/app/_includes/contact-section.html
+++ b/app/_includes/contact-section.html
@@ -1,4 +1,4 @@
-<section class="container pb-72 md:pb-84">
+<section class="container">
   <div class="flex flex-col md:grid md:grid-cols-3 gap-6 md:gap-40">
     <h2 class="h2">{{ include.heading }}</h2>
     <div class="md:col-span-2 body-text flex flex-col pt-24 flex flex-col md:grid md:grid-cols-2 gap-32">

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40">
+<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 mt-72 md:mt-84">
   <div class="nav-container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 mt-72 md:mt-84">
+<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 {% unless page.slug == 'our-work' %} mt-[theme(footerPadding.sm)] md:mt-[theme(footerPadding.lg)] {% endunless %}">
   <div class="nav-container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>

--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 {% unless page.slug == 'our-work' %} mt-[theme(footerPadding.sm)] md:mt-[theme(footerPadding.lg)] {% endunless %}">
+<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 {% unless page.slug == 'our-work' %} mt-[theme(footerPadding.sm)] md:mt-[theme(footerPadding.md)] {% endunless %}">
   <div class="nav-container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>

--- a/app/_layouts/event.html
+++ b/app/_layouts/event.html
@@ -20,7 +20,7 @@ custom-css: ['post-content']
   </div>
 </section>
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text">
     <div class="md:col-span-8 md:col-start-3" itemprop="articleBody">
         {% if page.banner %}
           <img src="{{ site.baseurl }}/assets/images/events/{{ page.banner }}"

--- a/app/_layouts/event.html
+++ b/app/_layouts/event.html
@@ -20,7 +20,7 @@ custom-css: ['post-content']
   </div>
 </section>
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-150">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
     <div class="md:col-span-8 md:col-start-3" itemprop="articleBody">
         {% if page.banner %}
           <img src="{{ site.baseurl }}/assets/images/events/{{ page.banner }}"

--- a/app/_layouts/our_work.html
+++ b/app/_layouts/our_work.html
@@ -13,7 +13,7 @@ custom-css: ['post-content']
 </section>
 
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-150">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
     <div class="md:col-span-8 md:col-start-3 flex flex-col gap-72" itemprop="articleBody">
       <div class="post-content">
         {{ content }}

--- a/app/_layouts/our_work.html
+++ b/app/_layouts/our_work.html
@@ -13,7 +13,7 @@ custom-css: ['post-content']
 </section>
 
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text">
     <div class="md:col-span-8 md:col-start-3 flex flex-col gap-72" itemprop="articleBody">
       <div class="post-content">
         {{ content }}

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -17,7 +17,7 @@ custom-css: ['post-content']
   </div>
 </section>
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-150">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
     <header class="grid grid-cols-2 md:flex md:col-span-3">
       <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
       <div class="md:hidden">

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -17,7 +17,7 @@ custom-css: ['post-content']
   </div>
 </section>
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text pb-72 md:pb-84">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text">
     <header class="grid grid-cols-2 md:flex md:col-span-3">
       <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
       <div class="md:hidden">

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -12,7 +12,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-40 md:gap-80 items-start pb-72 md:pb-84">
+<div class="flex flex-col gap-40 md:gap-80 items-start">
 
   <section class="container flex flex-col gap-120">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -12,7 +12,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-40 md:gap-80 items-start pb-50 md:pb-100">
+<div class="flex flex-col gap-40 md:gap-80 items-start pb-72 md:pb-84">
 
   <section class="container flex flex-col gap-120">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -5,7 +5,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80 pb-72 md:pb-84">
+<section class="pt-40 md:pt-80">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -5,7 +5,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80 pb-40 md:pb-200">
+<section class="pt-40 md:pt-80 pb-72 md:pb-84">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -110,7 +110,7 @@ layout: default
     </section>
   </section>
 
-  <section class="container pb-120 md:pb-220 flex flex-col gap-80 md:gap-160">
+  <section class="container flex flex-col gap-80 md:gap-160 pb-72 md:pb-84">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
       <h2 class="h2">Supported By</h2>
     </div>

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -8,7 +8,7 @@ layout: default
 <section class="container">
   <div class="page-hero">
     <h1 class="page-hero__title">{{ page.title }}</h1>
-    <h2 class="page-hero__subtitle">{{page.description}}</h2>
+    <div class="page-hero__subtitle">{{page.description}}</div>
   </div>
 </section>
 

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -110,7 +110,7 @@ layout: default
     </section>
   </section>
 
-  <section class="container flex flex-col gap-80 md:gap-160 pb-72 md:pb-84">
+  <section class="container flex flex-col gap-80 md:gap-160">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
       <h2 class="h2">Supported By</h2>
     </div>

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -7,7 +7,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80 pb-40 md:pb-200">
+<section class="pt-40 md:pt-80 pb-72 md:pb-84">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -7,7 +7,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80 pb-72 md:pb-84">
+<section class="pt-40 md:pt-80">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/contact/index.html
+++ b/app/contact/index.html
@@ -8,7 +8,7 @@ layout: default
 <section class="container">
   <div class="page-hero">
     <h1 class="page-hero__title">{{ page.title }}</h1>
-    <h2 class="page-hero__subtitle">{{page.description}}</h2>
+    <div class="page-hero__subtitle">{{page.description}}</div>
   </div>
 </section>
 

--- a/app/events.html
+++ b/app/events.html
@@ -10,7 +10,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-56 pb-72 md:pb-84">
+<div class="flex flex-col gap-56">
 
   {% assign next_event = site.events | where_exp: 'item','item.date >= site.time' | sort: 'date' | first %}
   {% if next_event %}

--- a/app/events.html
+++ b/app/events.html
@@ -10,7 +10,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-56 pb-150">
+<div class="flex flex-col gap-56 pb-72 md:pb-84">
 
   {% assign next_event = site.events | where_exp: 'item','item.date >= site.time' | sort: 'date' | first %}
   {% if next_event %}

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -7,8 +7,8 @@ layout: default
 <section class="container">
   <div class="page-hero simple">
     <h1 class="page-hero__title">{{ page.title }}</h1>
-    <div class="page-hero__subtitle flex flex-col gap-24">
-      <span>Joining our team means standing at the intersection of law, librarianship, and technology within an academic context. We offer a low pressure, self-directed environment with lots of room to explore, learn, collaborate, and teach.</span>
+    <div class="page-hero__subtitle">
+      Joining our team means standing at the intersection of law, librarianship, and technology within an academic context. We offer a low pressure, self-directed environment with lots of room to explore, learn, collaborate, and teach.
     </div>
   </div>
 </section>

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -7,9 +7,9 @@ layout: default
 <section class="container">
   <div class="page-hero simple">
     <h1 class="page-hero__title">{{ page.title }}</h1>
-    <h2 class="page-hero__subtitle flex flex-col gap-24">
+    <div class="page-hero__subtitle flex flex-col gap-24">
       <span>Joining our team means standing at the intersection of law, librarianship, and technology within an academic context. We offer a low pressure, self-directed environment with lots of room to explore, learn, collaborate, and teach.</span>
-    </h2>
+    </div>
   </div>
 </section>
 

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -13,7 +13,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-50 md:gap-80 pb-80 md:pb-200">
+<div class="flex flex-col gap-50 md:gap-80 pb-72 md:pb-84">
   <section>
     <figure>
       <picture>

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -13,7 +13,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-50 md:gap-80 pb-72 md:pb-84">
+<div class="flex flex-col gap-50 md:gap-80">
   <section>
     <figure>
       <picture>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -94,7 +94,7 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-24 md:pt-80 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.lg)] ">
+  <section class="bg-yellow pt-24 md:pt-80 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.md)] ">
     <div class="container flex flex-col gap-40">
       <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
         <h2 class="h2">Past Projects</h2>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -1,7 +1,7 @@
 ---
 title: Our Work
+slug: our-work
 subtitle: We build, research, and explore new technology through the lens of library principles.
-slug: projects
 description: "Our projects attempt to make something better, simpler, more transparent, or more fun."
 layout: default
 ---
@@ -94,7 +94,7 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-24 md:pt-80">
+  <section class="bg-yellow pt-24 md:pt-80 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.lg)] ">
     <div class="container flex flex-col gap-40">
       <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
         <h2 class="h2">Past Projects</h2>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -10,7 +10,7 @@ layout: default
   <section class="container">
     <div class="page-hero">
       <h1 class="page-hero__title">{{ page.title }}</h1>
-      <h2 class="page-hero__subtitle">{{page.subtitle}}</h2>
+      <div class="page-hero__subtitle">{{page.subtitle}}</div>
     </div>
   </section>
 

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -94,7 +94,7 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-24 md:pt-80 pb-72 md:pb-84">
+  <section class="bg-yellow pt-24 md:pt-80">
     <div class="container flex flex-col gap-40">
       <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
         <h2 class="h2">Past Projects</h2>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -94,7 +94,7 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-24 md:pt-80 pb-40">
+  <section class="bg-yellow pt-24 md:pt-80 pb-72 md:pb-84">
     <div class="container flex flex-col gap-40">
       <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
         <h2 class="h2">Past Projects</h2>

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -86,7 +86,11 @@ module.exports = {
             acc[val] = `${val}px`
             return acc
           }, {}),
-      }
+      },
+      footerPadding: {
+        sm: '72px',
+        lg: '84px'
+      },
     },
     keyframes: {
       'rotate': {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -89,7 +89,7 @@ module.exports = {
       },
       footerPadding: {
         sm: '72px',
-        md: '84px'
+        md: '120px'
       },
     },
     keyframes: {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -89,7 +89,7 @@ module.exports = {
       },
       footerPadding: {
         sm: '72px',
-        lg: '84px'
+        md: '84px'
       },
     },
     keyframes: {


### PR DESCRIPTION
The current implementation controls how much space is between the main content and the footer by separately applying bottom padding to the final pre-footer element of each page, and it uses a variety of different values.

This PR standardizes the amount of space, by instead setting a margin on the footer. 

Because there is one page that needs special handling ("Our Work", where the margin needs to be yellow), it extracts the desired spacing into custom tailwind "theme" values, so that they can be reused.

I went with the spacing used on the homepage.

If it turns out we want more, that can easily be changed in one spot, just by adjusting the theme values :-).

This PR temporarily makes the vertical spacing of the "Supported By" section of the "About" page even more haphazard. Fear not! Another PR will follow shortly, refactoring that section.