### PR TITLE
"About" page spacing

### DIFF
--- a/app/_data/supporters.yaml
+++ b/app/_data/supporters.yaml
@@ -1,0 +1,15 @@
+
+- name: Harvard Law School
+  logo: harvard-law-school-logo.png
+
+- name: Filecoin Foundation for the Decentralized Web
+  logo: ffdw-logo.png
+
+- name: LexisNexis
+  logo: lexisnexis-logo.png
+
+- name: OpenAI
+  logo: openai-logo.png
+
+- name: Meta
+  logo: meta-logo.png

--- a/app/_includes/about-people-affiliated.html
+++ b/app/_includes/about-people-affiliated.html
@@ -1,6 +1,6 @@
 {% assign person = include.person %}
 
-  <div class="flex flex-col gap-28 relative py-32 lg:py-50" id="{{ person.name | slugify }}">
+  <div class="flex flex-col gap-24 relative pt-32 lg:pt-48" id="{{ person.name | slugify }}">
     {% if include.border == 'true' %}
       <div class="hidden md:block absolute md:-right-30 lg:-right-60 -top-10 md:top-0 w-1 h-full bg-black"></div>
     {% endif %}
@@ -10,7 +10,7 @@
     {% endif %}
 
     <figure>
-      <img class="w-full relative overflow-hidden rounded-full max-w-[75%] m-auto" src=" {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }}"
+      <img class="w-full relative overflow-hidden rounded-full max-w-[75%] sm:max-w-[100%] mx-auto" src=" {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }}"
            srcset=" {{ site.baseurl }}/assets/thumbs/216x216c/{{ person.image }} 216w,
                     {{ site.baseurl }}/assets/thumbs/432x432c/{{ person.image }} 432w,
                     {{ site.baseurl }}/assets/thumbs/648x648c/{{ person.image }} 648w"

--- a/app/_includes/about-people-unaffiliated.html
+++ b/app/_includes/about-people-unaffiliated.html
@@ -3,8 +3,8 @@
 <div class="body-text w-full py-30 {% unless forloop.first %}border-t-1{% endunless %} border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative" id="{{ person.name | slugify }}">
   <div class="label md:col-span-3">{{person.name}}</div>
   <div class="md:col-span-6">{{person.role}}</div>
-  <div class="pt-20 md:pt-0 md:col-span-3 flex md:justify-end">
-    {% if person.website or person.twitter_account_name or person.github_account_name %}
+  {% if person.website or person.twitter_account_name or person.github_account_name %}
+  <div class="pt-6 md:pt-0 md:col-span-3 flex md:justify-end">
       <ul class="flex items-center gap-12 md:gap-24">
         {% if person.website %}
           <li class="website">
@@ -31,6 +31,6 @@
           </li>
         {% endif %}
       </ul>
-    {% endif %}
   </div>
+  {% endif %}
 </div>

--- a/app/_includes/about-people-unaffiliated.html
+++ b/app/_includes/about-people-unaffiliated.html
@@ -1,6 +1,6 @@
 {% assign person = include.person %}
 
-<div class="body-text w-full py-32 {% unless forloop.first %}border-t-1{% endunless %} border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative" id="{{ person.name | slugify }}">
+<div class="body-text w-full py-30 {% unless forloop.first %}border-t-1{% endunless %} border-black flex grid grid-cols-1 md:grid-cols-12 gap-4 md:gap-24 relative" id="{{ person.name | slugify }}">
   <div class="label md:col-span-3">{{person.name}}</div>
   <div class="md:col-span-6">{{person.role}}</div>
   <div class="pt-20 md:pt-0 md:col-span-3 flex md:justify-end">

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -12,7 +12,7 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col items-start gap-40 md:gap-80">
+<div class="flex flex-col items-start gap-48 md:gap-84">
 
   <section class="container">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
@@ -110,16 +110,12 @@ layout: default
     </section>
   </section>
 
-  <section class="container flex flex-col gap-80 md:gap-160">
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
-      <h2 class="h2">Supported By</h2>
-    </div>
-    <div class="flex flex-wrap gap-x-[10vw] gap-y-100 items-center justify-center max-w-[500px] mx-auto">
-      <img src="/assets/images/harvard-law-school-logo.png" alt="Harvard Law School Logo" />
-      <img src="/assets/images/ffdw-logo.png" alt="Filecoin Foundation for the Decentralized Web Logo" />
-      <img src="/assets/images/lexisnexis-logo.png" alt="LexisNexis Logo" />
-      <img src="/assets/images/openai-logo.png" alt="OpenAI Logo" />
-      <img src="/assets/images/meta-logo.png" alt="Meta Logo" />
+  <section class="container">
+    <h2 class="h2 mb-48 tbl:mb-36 md:mb-84">Supported By</h2>
+    <div class="flex flex-wrap flex-col tbl:grid tbl:grid-cols-2 xl:grid-cols-3 gap-y-24 sm:gap-y-36 tbl:gap-y-18 md:gap-y-36 lg:gap-y-48 items-center justify-center">
+      {% for supporter in site.data.supporters %}
+        <div class="tbl:m-auto"><img class="max-w-[50vw] sm:max-w-auto" src="/assets/images/{{ supporter.logo }}" alt="{{ supporter.name }} Logo" /></div>
+      {% endfor %}
     </div>
   </section>
 

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -12,12 +12,12 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col items-start gap-48 md:gap-72">
+<div class="flex flex-col items-start gap-36 md:gap-72">
 
-  <section class="container mb-12">
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
+  <section class="container md:mb-12">
+    <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
       <h2 class="h2">Who We Are</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-32 md:pt-20 max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-24 md:pt-20 max-w-[700px]">
         <p>We are a team of librarians, technologists, lawyers, designers, and more, and we work out of the Harvard Law School Library.</p>
         <p>We believe that libraries play a fundamental role in humanity as open, privacy-respecting, and sustainable information spaces. We also believe technology holds great power to break down barriers to information creation, preservation, and use.</p>
       </div>
@@ -37,7 +37,7 @@ layout: default
     </figure>
   </section>
 
-  <section class="bg-green py-72 w-full">
+  <section class="bg-green py-48 md:py-72 w-full">
     <div class="container flex flex-col md:grid md:grid-cols-2 gap-32 md:gap-100 md:items-center">
       <h2 class="h2">Library principles can manifest in any technology and provide a roadmap to mindful building.</h2>
       <div class="flex flex-col gap-20 md:gap-30 body-text">
@@ -52,7 +52,7 @@ layout: default
   </section>
 
   <section class="container ">
-    <h2 class="h2 mt-12 mb-72">The People at the Lab</h2>
+    <h2 class="h2 mt-12 mb-48 md:mb-72">The People at the Lab</h2>
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120 pb-48 md:pb-72">
       {% assign affiliates = site.data.people | where: "affiliated", true | sort: "sort_name" %}
       {% assign sections = "Faculty Director, Staff" | split: ", " %}
@@ -69,7 +69,7 @@ layout: default
         {% endif %}
       {% endfor %}
     </div>
-    <div class="pt-72 border-t-1 border-black">
+    <div class="pt-48 md:pt-72 border-t-1 border-black">
       <h2 class="h2">Fellows</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
         {% assign fellows = site.data.people | where: "affiliated", true | sort: "sort_name" %}
@@ -97,9 +97,9 @@ layout: default
       <div class="w-40">
       </div>
     </div>
-    <section class="bg-gray pt-60 pb-24 w-full">
+    <section class="bg-gray pt-48 pb-6 tbl:pt-60 tbl:pb-24 w-full">
       <div class="container">
-        <h2 class="h2 mt-12 mb-24">Past Affiliates</h2>
+        <h2 class="h2 tbl:mt-12 tbl:mb-24">Past Affiliates</h2>
         <div class="flex flex-col items-start w-full">
           {% assign old_friends = affiliates | where: "current", nil %}
           {% for person in old_friends %}
@@ -111,7 +111,7 @@ layout: default
   </section>
 
   <section class="container">
-    <h2 class="h2 mb-48 tbl:mb-36 md:mb-60">Supported By</h2>
+    <h2 class="h2 mt-12 md:mt-0 mb-48 tbl:mb-36 md:mb-60">Supported By</h2>
     <div class="flex flex-wrap flex-col tbl:grid tbl:grid-cols-2 xl:grid-cols-3 gap-y-24 sm:gap-y-36 tbl:gap-y-18 md:gap-y-36 lg:gap-y-48 items-center justify-center">
       {% for supporter in site.data.supporters %}
         <div class="tbl:m-auto"><img class="max-w-[50vw] sm:max-w-auto" src="/assets/images/{{ supporter.logo }}" alt="{{ supporter.name }} Logo" /></div>

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -12,9 +12,9 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col items-start gap-48 md:gap-84">
+<div class="flex flex-col items-start gap-48 md:gap-72">
 
-  <section class="container">
+  <section class="container mb-12">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
       <h2 class="h2">Who We Are</h2>
       <div class="md:col-span-2 body-text flex flex-col gap-32 md:pt-20 max-w-[700px]">
@@ -37,7 +37,7 @@ layout: default
     </figure>
   </section>
 
-  <section class="bg-green py-80 w-full">
+  <section class="bg-green py-72 w-full">
     <div class="container flex flex-col md:grid md:grid-cols-2 gap-32 md:gap-100 md:items-center">
       <h2 class="h2">Library principles can manifest in any technology and provide a roadmap to mindful building.</h2>
       <div class="flex flex-col gap-20 md:gap-30 body-text">
@@ -51,9 +51,9 @@ layout: default
     </div>
   </section>
 
-  <section class="container flex flex-col gap-50">
-    <h2 class="h2 pb-50">The People at the Lab</h2>
-    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
+  <section class="container ">
+    <h2 class="h2 mt-12 mb-72">The People at the Lab</h2>
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120 pb-48 md:pb-72">
       {% assign affiliates = site.data.people | where: "affiliated", true | sort: "sort_name" %}
       {% assign sections = "Faculty Director, Staff" | split: ", " %}
       {% for section in sections %}
@@ -69,7 +69,7 @@ layout: default
         {% endif %}
       {% endfor %}
     </div>
-    <div class="flex flex-col gap-32 pt-50 border-t-1 border-black">
+    <div class="pt-72 border-t-1 border-black">
       <h2 class="h2">Fellows</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
         {% assign fellows = site.data.people | where: "affiliated", true | sort: "sort_name" %}
@@ -87,19 +87,19 @@ layout: default
   </section>
 
   <section class="w-full bg-purple">
-    <div class="container flex items-center justify-between gap-20 py-20">
+    <div class="container flex items-center justify-between gap-20 py-24">
       <div>
         {% include header-splash-logo.html %}
       </div>
       <div>
-        {% include arrow-link.html label="View Open Positions" href="/jobs" %}
+        {% include arrow-link.html label="View Open Positions" href="/jobs/" %}
       </div>
       <div class="w-40">
       </div>
     </div>
-    <section class="bg-gray pt-80 pb-40 w-full">
-      <div class="container flex flex-col gap-80">
-        <h2 class="h2">Past Affiliates</h2>
+    <section class="bg-gray pt-60 pb-24 w-full">
+      <div class="container">
+        <h2 class="h2 mt-12 mb-24">Past Affiliates</h2>
         <div class="flex flex-col items-start w-full">
           {% assign old_friends = affiliates | where: "current", nil %}
           {% for person in old_friends %}
@@ -111,7 +111,7 @@ layout: default
   </section>
 
   <section class="container">
-    <h2 class="h2 mb-48 tbl:mb-36 md:mb-84">Supported By</h2>
+    <h2 class="h2 mb-48 tbl:mb-36 md:mb-60">Supported By</h2>
     <div class="flex flex-wrap flex-col tbl:grid tbl:grid-cols-2 xl:grid-cols-3 gap-y-24 sm:gap-y-36 tbl:gap-y-18 md:gap-y-36 lg:gap-y-48 items-center justify-center">
       {% for supporter in site.data.supporters %}
         <div class="tbl:m-auto"><img class="max-w-[50vw] sm:max-w-auto" src="/assets/images/{{ supporter.logo }}" alt="{{ supporter.name }} Logo" /></div>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -468,8 +468,8 @@ html.is-animating .transition-main {
 
 @media (max-width: 859px) {
   .page-hero {
-    padding-bottom: 40px;
-    margin-bottom: 40px;
+    padding-bottom: 36px;
+    margin-bottom: 36px;
     padding-top: 60px;
   }
   

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -89,7 +89,7 @@ module.exports = {
       },
       footerPadding: {
         sm: '72px',
-        md: '120px'
+        md: '96px'
       },
     },
     keyframes: {


### PR DESCRIPTION
This is a first pass at regularizing the vertical spacing on the "About" page. I think it could use a second pass, but it gets us closer.

The overall strategy is, as with my past PRs of this kind, a) to start replacing "magic numbers" with multiples of 12; b) to try and balance space above and space below elements; c) a little, to try and apply consistent spacing across sections (though this last project, is proving tricky... I think it will become easier abstract patterns as we continue).

This PR also adds a first try at implementing the multi-column display of logos at the bottom, and reverts a bug I introduced, where portraits widths were accidentally capped at large screen sizes (in addition to small).

Known to still be buggy:

The placement of the "Faculty Director" and "Staff" labels in the people gallery is achieved in such a way that, it makes it VERY difficult to adjust the vertical spacing of each person's card. Briefly: _every_ person's card contains enough vertical spacing to accommodate that label, even if it isn't present. So, there is much too much space between cards, everywhere except between the "The People at the Lab" header and the first two cards. And, since this applies to the "Fellows" section as well, where there is no label... It makes the spacing between the "Fellows" heading and the first card Just Weird™️.

I could not get the "staggered" column of the design working, with the logos at the bottom of the page, even though I _think_ that is possible with CSS grid...

And, the visual hierarchy of the logo section is off, at small viewport sizes.

And, again, I think the whole thing could possibly use another pass.

Here, though, are some before and after screenshots.

Before:

![image](https://github.com/user-attachments/assets/45cef40f-effe-4f8d-83ce-62bb70807171)

After:

![image](https://github.com/user-attachments/assets/b7e454dc-1045-4a42-8210-0a9e7c667eee)

___ 

Before:

![image](https://github.com/user-attachments/assets/3f533c79-36c0-4440-acef-ce7fc6ec6981)

After:

![image](https://github.com/user-attachments/assets/3716ca3b-989b-4bb8-9d8e-a2e5cca3079c)

___

Before:

![image](https://github.com/user-attachments/assets/6fca6e34-bc68-4959-88de-e1f76d02a07a)

After:

![image](https://github.com/user-attachments/assets/4f549ab9-1ed2-4c5a-b0bd-bff748bcbc08)

___

Before:

![image](https://github.com/user-attachments/assets/c3b3bd60-50a5-4801-89d8-e68d54337c6b)

After:

![image](https://github.com/user-attachments/assets/bd67cc66-f7e5-4c08-ae2f-0c2d3dd09f5e)

___

Before:

![image](https://github.com/user-attachments/assets/a8fd0f56-0cd6-4c72-b92d-d0d8e776c659)


After:

![image](https://github.com/user-attachments/assets/0ec5ea89-f60d-4cc7-9a9f-86620f371e7f)
