### PR TITLE
Assorted spacing

### DIFF
--- a/app/_events/transform-journalism.md
+++ b/app/_events/transform-journalism.md
@@ -1,8 +1,8 @@
 ---
 # mandatory
 title: "Transform: Journalism"
-date: 2024-10-23 19:05:36+00:00
-date_informal: Fall 2024
+date: 2025-03-01 19:05:36+00:00
+date_informal: Spring 2025
 short_description: "An invite-only workshop for experts trying to reconcile the tensions between AI growth and journalism."
 description: "Transform: Journalism will be a closed-door gathering of experts from intersecting fields grappling with the interaction of generative AI and journalism."
 

--- a/app/_includes/author.html
+++ b/app/_includes/author.html
@@ -1,14 +1,14 @@
 <div>
 {% if include.author %}
   <h2>Authors:</h2>
-  <p class="post-author">
+  <span class="post-author">
   {% for author in include.author %}
     {% assign person_record = site.data.people[author] %}
     {% if forloop.last and forloop.length > 1 %} and {% endif %}
     <a href="{{ site.baseurl }}/about/#{{person_record.name | slugify }}" class="interactive-link dark reverse">{{ person_record.name }}</a>{% if forloop.last != true and forloop.length > 2 %}, {% endif %}
   {% endfor %}
-  </p>
+  </span>
   {% elsif include.guest-author %}
-    <p class="post-author">{{ include.guest-author }}</p>
+    <span class="post-author">{{ include.guest-author }}</span>
   {% endif %}
 </div>

--- a/app/_includes/contact-section.html
+++ b/app/_includes/contact-section.html
@@ -5,7 +5,10 @@
       <div class="flex flex-col gap-28">
         <div class="label-value">
           <h3 class="label">Email</h3>
-          <a href="mailto:{{ site.email }}" class="value interactive-link dark reverse">{{ site.email }}</a>
+          {% capture emailLink %}
+            mailto:{{ site.email }}
+          {% endcapture %}
+          {% include arrow-link-inline.html label=site.email href=emailLink reverse=true %}
         </div>
         <div class="label-value">
           <h3 class="label">Contact us in person</h3>

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -10,7 +10,7 @@
       </a>
     </lil-marquee>
   {% endif %}
-  <header class="pt-12 md:pt-36 nav-container">
+  <header class="pt-24 md:pt-36 nav-container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>
       <a href="/" class="logo">

--- a/app/_includes/tag-filter.html
+++ b/app/_includes/tag-filter.html
@@ -4,7 +4,7 @@
 
 <div>
   <nav aria-label="Featured Tags">
-    <ul class="flex flex-wrap items-center gap-10">
+    <ul class="flex flex-wrap flex-col sm:flex-row gap-10 mt-12 sm:mt-0">
       {% for tag in site.data.featured_tags %}
         {% assign isActive = false  %}
         {% if current == tag %}
@@ -17,7 +17,7 @@
         {% endfor %}
         <li>
           <a
-            class="block text-14 md:text-16 px-10 py-6 md:px-24 md:py-12 border-1 border-black text-black active:text-white active:bg-black md:hover:text-white md:hover:bg-black transition-colors duration-300 ease {% if isActive %}bg-black text-white{% endif %}" 
+            class="block text-14 tbl:text-16 px-10 py-6 tbl:px-24 tbl:py-12 border-1 border-black text-black active:text-white active:bg-black tbl:hover:text-white md:hover:bg-black transition-colors duration-300 ease {% if isActive %}bg-black text-white{% endif %}"
             href="{% if current == tag %}{{ site.baseurl }}/blog{% else %}{{ site.baseurl }}/blog/tag/{{ tag | slugify}}/{% endif %}"{% if current == tag %} aria-current="true"{% endif %}
             data-no-swup
           >

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -4,7 +4,7 @@ custom-css: ['post-content']
 ---
 
 <section class="container pt-48 md:pt-72">
-  <div class="flex flex-col gap-36 md:gap-48 mb-24 md:mb-36">
+  <div class="flex flex-col gap-48 mb-36">
     {% include tag-filter.html tags=page.tags %}
     <div class="flex flex-col items-start gap-12 md:gap-24">
       <nav aria-label="breadcrumbs">
@@ -17,17 +17,16 @@ custom-css: ['post-content']
   </div>
 </section>
 <section class="container post">
-  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-24 md:grid md:grid-cols-12 body-text">
-    <header class="grid grid-cols-2 md:flex md:col-span-3">
-      <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
-      <div class="md:hidden">
+  <article role="article" itemscope itemtype="http://schema.org/BlogPosting" class="flex flex-col gap-20 md:gap-36 md:grid md:grid-cols-12 body-text">
+    <header class="flex flex-col gap-20 md:col-span-3">
+      <div>
         {% include author.html author=page.author guest-author=page.guest-author %}
       </div>
+      <div>
+        <p>Published:</p>
+        <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
     </header>
-    <div class="md:col-span-7 flex flex-col gap-32 md:gap-72" itemprop="articleBody">
-      <div class="hidden md:block">
-        {% include author.html author=page.author guest-author=page.guest-author %}
-      </div>
+    <div class="md:col-span-7" itemprop="articleBody">
       <div class="post-content">
         {{ content }}
       </div>

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -3,14 +3,14 @@ layout: default
 custom-css: ['post-content']
 ---
 
-<section class="container pt-50 md:pt-80">
-  <div class="flex flex-col gap-50 md:gap-120 mb-14 md:mb-56">
+<section class="container pt-48 md:pt-72">
+  <div class="flex flex-col gap-36 md:gap-48 mb-24 md:mb-36">
     {% include tag-filter.html tags=page.tags %}
-    <div class="flex flex-col items-start gap-10 md:gap-20">
+    <div class="flex flex-col items-start gap-12 md:gap-24">
       <nav aria-label="breadcrumbs">
         <a href="{{ site.baseurl }}/blog/" class="label interactive-link dark reverse">Blog</a>
       </nav>
-      <div class="w-full flex flex-col md:grid gap-14 md:gap-32 pb-40 border-b-1 border-black">
+      <div class="w-full pb-36 border-b-1 border-black">
         <h1 class="h2">{{page.title}}</h1>
       </div>
     </div>

--- a/app/_layouts/post.html
+++ b/app/_layouts/post.html
@@ -25,6 +25,7 @@ custom-css: ['post-content']
       <div>
         <p>Published:</p>
         <time class="post-date" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+      </div>
     </header>
     <div class="md:col-span-7" itemprop="articleBody">
       <div class="post-content">

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -3,21 +3,21 @@ layout: default
 ---
 
 <section class="container">
-  <div class="page-hero">
+  <div class="page-hero project">
     <nav aria-label="breadcrumbs" class="page-hero__eyebrow">
-      <a href="{{ site.baseurl }}/our-work/" class="interactive-link dark">Our Work > {{ page.category }}</a>
+      <a href="{{ site.baseurl }}/our-work/" class="interactive-link dark reverse">Our Work</a>
     </nav>
     <h1 class="page-hero__title">{{ page.title }}</h1>
     <h2 class="page-hero__subtitle">{{page.what_does_it_do}}</h2>
   </div>
 </section>
 
-<div class="flex flex-col gap-40 md:gap-80 items-start">
+<div class="flex flex-col gap-48 md:gap-60 items-start">
 
-  <section class="container flex flex-col gap-120">
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
+  <section class="container flex flex-col gap-36 md:gap-72">
+    <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
       <h2 class="h2">Where can I find {{page.title}}?</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-32 pt-20 max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-12 pt-20 xl:max-w-[700px]">
         {% if page.project_website %}
           {% include arrow-link.html label=page.project_website href=page.project_website target="_blank" %}
         {% endif %}
@@ -26,16 +26,10 @@ layout: default
         {% endif %}
       </div>
     </div>
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
-      <h2 class="h2">What does {{page.title}} do?</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-32 pt-20 max-w-[700px]">
-        {{ page.what_does_it_do | markdownify }}
-      </div>
-    </div>
     {% if page.why_does_it_exist %}
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
+      <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
         <h2 class="h2">Why does {{page.title}} exist?</h2>
-        <div class="md:col-span-2 body-text flex flex-col gap-32 pt-20 max-w-[700px]">
+        <div class="md:col-span-2 body-text flex flex-col gap-20 pt-20 xl:max-w-[700px]">
           {{ page.why_does_it_exist | markdownify }}
         </div>
       </div>
@@ -48,11 +42,11 @@ layout: default
 
   {% assign news = site.data.news | where: "project", page.slug %}
   {% if news.size > 0 %}
-    <section class="container flex flex-col items-start gap-40">
+    <section class="container flex flex-col items-start gap-12">
       <h2 class="h2">News</h2>
       <div class="flex flex-col items-start w-full">
         {% for article in news %}
-          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
+          <div class="body-text w-full py-24 md:py-36 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
             <!-- format date as 02.12.24 -->
             <span class="label col-span-3">
               <span class="align-middle">{{ article.date | date: "%m/%d/%y" }}</span>
@@ -70,11 +64,11 @@ layout: default
   {% endif %}
   
   {% if page.who_contributed %}
-    <section class="container pb-40">
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
+    <section class="container">
+      <div class="flex flex-col lg:grid lg:grid-cols-3 gap-24 lg:gap-36">
         <h2 class="h2">Project Contributors</h2>
 
-        <div class="slice-body additional-contributors md:col-span-2 md:pt-20 body-text max-w-[750px]">
+        <div class="slice-body additional-contributors lg:col-span-2 lg:pt-20 body-text lg:max-w-[750px]">
           {% for name in page.who_contributed %}
             {% assign person = site.data.people[name] %}
             <strong class="name">{{ person.name }}</strong>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -322,7 +322,7 @@ lil-header.expanded .nav-menu__inner {
 .page-hero {
   padding-bottom: 72px;
   border-bottom: 1px solid #121212;
-  margin-bottom: 80px;
+  margin-bottom: 60px;
   padding-top: 120px;
 }
 
@@ -341,7 +341,7 @@ lil-header.expanded .nav-menu__inner {
 
 .page-hero.simple {
   margin-bottom: 0;
-  padding-bottom: 80px;
+  padding-bottom: 72px;
   border-bottom: 0;
 }
 
@@ -349,10 +349,19 @@ lil-header.expanded .nav-menu__inner {
   max-width: 980px;
 }
 
+.page-hero.project {
+  padding-bottom: 60px;
+}
+
+.page-hero.project .page-hero__title {
+  margin-left: -8px;
+  padding-bottom: 16px;
+}
 
 .page-hero.events {
   padding-bottom: 0;
 }
+
 .page-hero.events .page-hero__title {
   padding-bottom: 72px;
 }
@@ -492,6 +501,14 @@ html.is-animating .transition-main {
 
   .page-hero.events .page-hero__title {
     padding-bottom: 36px;
+  }
+
+  .page-hero.project {
+    padding-bottom: 40px;
+  }
+
+  .page-hero.project .page-hero__title {
+    margin-left: -4px;
   }
 
   .body-text, .expandable__content {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -315,11 +315,12 @@ lil-header.expanded .nav-menu__inner {
   line-height: 115%;
 }
 
+.page-hero__eyebrow {
+  margin-bottom: 24px;
+}
+
 .page-hero {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-  padding-bottom: 80px;
+  padding-bottom: 72px;
   border-bottom: 1px solid #121212;
   margin-bottom: 80px;
   padding-top: 120px;
@@ -329,7 +330,7 @@ lil-header.expanded .nav-menu__inner {
   font-size: clamp(52px, 12vw, 140px);
   font-weight: 500;
   line-height: 100%;
-  padding-bottom: 12px;
+  padding-bottom: 36px;
 }
 
 .page-hero__subtitle {
@@ -346,6 +347,14 @@ lil-header.expanded .nav-menu__inner {
 
 .page-hero.simple .page-hero__subtitle {
   max-width: 980px;
+}
+
+
+.page-hero.events {
+  padding-bottom: 0;
+}
+.page-hero.events .page-hero__title {
+  padding-bottom: 72px;
 }
 
 .body-text, .expandable__content {
@@ -475,6 +484,14 @@ html.is-animating .transition-main {
   
   .page-hero__subtitle {
     font-size: 28px;
+  }
+
+  .page-hero.events {
+    padding-bottom: 0;
+  }
+
+  .page-hero.events .page-hero__title {
+    padding-bottom: 36px;
   }
 
   .body-text, .expandable__content {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -552,7 +552,7 @@ html.is-animating .transition-main {
   }
 
   .page-hero__title {
-    padding-bottom: 0;
+    padding-bottom: 24px;
   }
 
 /*  .interactive-link {

--- a/app/events.html
+++ b/app/events.html
@@ -10,12 +10,12 @@ layout: default
   </div>
 </section>
 
-<div class="flex flex-col gap-56">
+<div>
 
   {% assign next_event = site.events | where_exp: 'item','item.date >= site.time' | sort: 'date' | first %}
   {% if next_event %}
     {% if next_event.banner %}
-      <section class="container">
+      <section class="container mb-30 tbl:mb-60">
         <div class="w-full relative">
           <figure>
             <picture>
@@ -34,18 +34,16 @@ layout: default
       {% endif %}
 
       <section class="container">
-        <div class="flex flex-col gap-50 md:gap-120">
-          <div class="flex flex-col items-start gap-20">
-            <div class="label">Next Event</div>
-            <div class="flex flex-col md:grid md:grid-cols-3 gap-32 pb-60">
-              <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
-              <div class="md:col-span-2 body-text max-w-[700px] pt-10 flex flex-col items-start gap-50">
-                {{ next_event.excerpt }}
-                {% capture linkLabel %}
-                  <span class="sr-only">{{ next_event.title }},</span> More Info
-                {% endcapture %}
-                {% include arrow-link.html label=linkLabel href=next_event.url reverse=true %}
-              </div>
+        <div class="flex flex-col items-start gap-12">
+          <div class="label">Next Event</div>
+          <div class="flex flex-col md:grid md:grid-cols-3 md:gap-36 pb-36 md:pb-48">
+            <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
+            <div class="md:col-span-2 body-text md:max-w-[700px] pt-20 flex flex-col items-start gap-20">
+              {{ next_event.excerpt }}
+              {% capture linkLabel %}
+                <span class="sr-only">{{ next_event.title }},</span> More Info
+              {% endcapture %}
+              {% include arrow-link.html label=linkLabel href=next_event.url reverse=true %}
             </div>
           </div>
         </div>
@@ -54,7 +52,7 @@ layout: default
 
   {% assign upcoming_events = site.events | where_exp: 'item','item.date > site.time' | sort: 'date' | reverse %}
   {% if upcoming_events.size > 0 %}
-    <section class="container">
+    <section class="container mb-36 md:mb-60">
       <h2 class="h2">Upcoming</h2>
       <div class="flex flex-col items-start w-full">
 
@@ -62,7 +60,7 @@ layout: default
           {% capture linkLabel %}
             <strong>{{event.title}}</strong> - {{event.short_description}}
           {% endcapture %}
-          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
+          <div class="body-text w-full {% if forloop.first %} py-24 tbl:py-36 {% else %}py-36 {% endif %} border-black {% unless forloop.first %}border-t-1{% endunless %} {% if forloop.last %}border-b-1{% endif %} flex flex-col md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
             <span class="col-span-6">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
           </div>
@@ -80,7 +78,7 @@ layout: default
           {% capture linkLabel %}
             <strong>{{event.title}}</strong> - {{event.short_description}}
           {% endcapture %}
-          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
+          <div class="body-text w-full {% if forloop.first %} pt-24 pb-36 tbl:py-36 {% elsif forloop.last %} pt-24 tbl:pt-36 {% else %} py-24 tbl:py-36 {% endif %}{% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
             <span class="col-span-6">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
           </div>

--- a/app/events.html
+++ b/app/events.html
@@ -80,7 +80,7 @@ layout: default
           {% endcapture %}
           <div class="body-text w-full {% if forloop.first %} pt-24 pb-36 tbl:py-36 {% elsif forloop.last %} pt-24 tbl:pt-36 {% else %} py-24 tbl:py-36 {% endif %}{% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
-            <span class="col-span-6">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
+            <span class="col-span-8">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
           </div>
         {% endfor %}
       </div>

--- a/app/events.html
+++ b/app/events.html
@@ -54,7 +54,7 @@ layout: default
 
   {% assign upcoming_events = site.events | where_exp: 'item','item.date > site.time' | sort: 'date' | reverse %}
   {% if upcoming_events.size > 0 %}
-    <section class="container flex flex-col items-start gap-10">
+    <section class="container">
       <h2 class="h2">Upcoming</h2>
       <div class="flex flex-col items-start w-full">
 
@@ -73,7 +73,7 @@ layout: default
 
   {% assign past_events = site.events | where_exp: 'item','item.date < site.time' | sort: 'date' | reverse %}
   {% if past_events.size > 0 %}
-    <section class="container flex flex-col items-start gap-10">
+    <section class="container">
       <h2 class="h2">Past</h2>
       <div class="flex flex-col items-start w-full">
         {% for event in past_events %}

--- a/app/events.html
+++ b/app/events.html
@@ -60,14 +60,11 @@ layout: default
 
         {% for event in upcoming_events %}
           {% capture linkLabel %}
-            <span class="sr-only"> {{ event.title }},</span> More Info
+            <strong>{{event.title}}</strong> - {{event.short_description}}
           {% endcapture %}
           <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
-            <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
-            <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">
-              {% include arrow-link.html label=linkLabel href=event.url target=target card_link="true" %}
-            </span>
+            <span class="col-span-6">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
           </div>
         {% endfor %}
       </div>
@@ -81,14 +78,11 @@ layout: default
       <div class="flex flex-col items-start w-full">
         {% for event in past_events %}
           {% capture linkLabel %}
-            <span class="sr-only"> {{ event.title }},</span> More Info
+            <strong>{{event.title}}</strong> - {{event.short_description}}
           {% endcapture %}
           <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
-            <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
-            <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">
-              {% include arrow-link.html label=linkLabel href=event.url target=target card_link="true" %}
-            </span>
+            <span class="col-span-6">{% include arrow-link-inline.html label=linkLabel href=event.url %}</span>
           </div>
         {% endfor %}
       </div>

--- a/app/events.html
+++ b/app/events.html
@@ -5,7 +5,7 @@ layout: default
 ---
 
 <section class="container">
-  <div class="page-hero">
+  <div class="page-hero events">
     <h1 class="page-hero__title">{{ page.title }}</h1>
   </div>
 </section>

--- a/app/events.html
+++ b/app/events.html
@@ -62,7 +62,7 @@ layout: default
           {% capture linkLabel %}
             <span class="sr-only"> {{ event.title }},</span> More Info
           {% endcapture %}
-          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+          <div class="body-text w-full py-32 border-t-1 border-black first-of-type:border-t-0 last-of-type:border-b-1 flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
             <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
             <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">
@@ -83,7 +83,7 @@ layout: default
           {% capture linkLabel %}
             <span class="sr-only"> {{ event.title }},</span> More Info
           {% endcapture %}
-          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative">
             <span class="label col-span-3">{{ event.date | date: "%m/%d/%y" }}</span>
             <span class="col-span-6"><strong>{{event.title}}</strong> - {{event.short_description}}</span>
             <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">

--- a/app/index.html
+++ b/app/index.html
@@ -35,7 +35,7 @@ sharing-card-type: summary_large_image
 <div class="container flex flex-col gap-50 md:gap-100">
   <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48">
     <h2 class="h2">Who We Are</h2>
-    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-24">
+    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
       <div class="flex flex-col gap-20">
         <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research that empowers access to our shared knowledge and cultural heritage.</p>
       </div>
@@ -72,7 +72,7 @@ sharing-card-type: summary_large_image
   <div class="container flex flex-col gap-50 md:gap-100">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black">
       <h2 class="h2">Our Work</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
+      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
         <div class="flex flex-col gap-20">
           <p>Platforms like Perma.cc translate the traditional roles of libraries into the digital age. Explorations like warcGPT empower practitioners to learn and leverage new technologies in the context of their field.</p>
         </div>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -56,10 +56,10 @@ layout: default
     </div>
   </section>
 
-  <section class="container pb-40 md:pb-80">
+  <section class="container pb-36">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
       <h2 class="h2">Platforms</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-24">
+      <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-18">
         <p class="flex flex-col gap-20 max-w-[700px]">
           Tools are the heart of the Library Innovation Lab. We build things. Our platforms each have their own user base and long-term goals.
         </p>
@@ -67,7 +67,7 @@ layout: default
     </div>
   </section>
 
-  <section class="flex flex-col gap-18 pb-40 md:pb-140">
+  <section class="flex flex-col gap-12 pb-12 tbl:gap-24 tbl:pb-24">
     {% assign active_platforms = site.our_work | where:"category","platforms" | where:"retired",false | sort: "order" %}
     {% for platform in active_platforms %}
       {% capture linkOneLabel %}

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -14,23 +14,19 @@ layout: default
     </div>
   </section>
 
-  <section class="container pt-40 pb-40 md:pb-200 md:pt-0 flex flex-col gap-50 md:gap-100">
-    <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
-      <h2 class="h2">Research</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-24">
-      </div>
-    </div>
+  <section class="container flex flex-col gap-24 md:gap-36 pb-72 md:pb-96">
+    <h2 class="h2">Research</h2>
 
-    <div class="flex flex-col gap-24 md:gap-40">
+    <div class="flex flex-col gap-24 md:gap-48">
 
       {% assign research = site.our_work | where:"category","research" | where:"retired",false %}
       {% assign active_research =  research | concat: site.data.additional_research %}
       {% assign subcategories = active_research | map: 'subcategory' | join: ',' | split: ',' | uniq | sort %}
 
       {% for category in subcategories %}
-        <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 w-full {% if forloop.last == false %} border-b-1 border-black pb-40 md:pb-32 {% endif %}">
-          <h3 class="label">{{ category }}</h3>
-          <div class="grid grid-cols-2 gap-16 md:gap-24 md:col-span-2 max-w-[900px]">
+        <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-48 w-full {% if forloop.last == false %} border-b-1 border-black pb-48 md:pb-60{% endif %}">
+          <h3 class="label {% unless forloop.first %} mt-12 md:mt-0 {% endunless %}">{{ category }}</h3>
+          <div class="grid grid-cols-2 gap-36 md:col-span-2">
 
             {% assign this_research = active_research | where:"subcategory",category | sort: 'title' %}
 

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -90,27 +90,23 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-24 md:pt-80 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.md)] ">
-    <div class="container flex flex-col gap-40">
-      <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
-        <h2 class="h2">Past Projects</h2>
-        <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-24">
-        </div>
-      </div>
+  <section class="bg-yellow pt-48 tbl:pt-72 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.md)] ">
+    <div class="container flex flex-col gap-12 md:gap-24">
+      <h2 class="h2">Past Projects</h2>
       <div class="flex flex-col">
         {% assign retired_projects_with_pages = site.our_work | where:"retired",true %}
         {% assign retired_projects_without_pages = site.our_work_pageless | where:"retired",true %}
         {% assign retired_projects = retired_projects_with_pages | concat: retired_projects_without_pages | sort: "retired_date" | reverse %}
         {% for project in retired_projects %}
-          <div class="body-text w-full py-32 {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 md:gap-24 relative md:items-center">
+          <div class="body-text w-full {% if forloop.last %} pt-24 tbl:pt-36 {% else %} py-24 tbl:py-36 {% endif %} {% unless forloop.first %}border-t-1 {% endunless %} border-black flex flex-col  md:grid md:grid-cols-12 gap-8 tbl:gap-24 relative">
             <h3 class="label col-span-3">{{ project.title }}</h3>
             <span class="col-span-6">{{ project.what_does_it_do }}</span>
             {% if project.collection == 'our_work' %}
               {% capture linkLabel %}
                 <span class="sr-only">{{ project.title }}, </span>Learn More
               {% endcapture %}
-              <span class="col-span-3 flex md:justify-end pt-20 md:pt-0">
-                {% include arrow-link.html label=linkLabel href=project.url target=target card_link="true" %}
+              <span class="col-span-3 flex md:justify-end">
+                {% include arrow-link-inline.html label=linkLabel href=project.url target=target card_link="true" %}
               </span>
             {% endif %}
           </div>


### PR DESCRIPTION
In this PR, I went through the Events page, Our Work page, and individual blog posts' pages, and took a pass at tidying all the vertical alignment and spacing, trying to standardizing things to fit on the same 12px grid we've been using, and trying to balance some of the whitespace.

I also spent some time working on column layouts, where text on the right is supposed to align with a heading on the left: I added whatever margin caused them to fall on the same baseline in my browser.

I also worked on the spacing of the featured tags in small viewports, when they started wrapping to two lines.

It's really difficult to get screenshots that show the changes effectively, since size/scale are so important.

Here are a few samples.

### Before

![image](https://github.com/user-attachments/assets/45738f07-e668-42f9-9a15-65b9e41ca1b4)
![image](https://github.com/user-attachments/assets/ac726b72-d28c-4901-b663-7c7931b8649b)

### After

![image](https://github.com/user-attachments/assets/715b4c08-c4b5-4be3-82f2-1d8ae5244c28)

### Before

![image](https://github.com/user-attachments/assets/e23beb28-ee9a-4955-8376-c0728649919f)

### After

![image](https://github.com/user-attachments/assets/167c0f5e-3009-4f80-9ab6-ad42b424188b)

### Before

![image](https://github.com/user-attachments/assets/10008baf-e512-4e48-ac0a-e59093d58d71)

### After

![image](https://github.com/user-attachments/assets/4dc9ab84-0e9a-4d67-82b9-3175a8e551cd)

### Before

![image](https://github.com/user-attachments/assets/45f2bffb-a6f8-4535-a4db-736a9d3af481)
![image](https://github.com/user-attachments/assets/c834a965-a729-471a-a7ef-532257768ada)

### After

![image](https://github.com/user-attachments/assets/f81244a9-3150-41b6-a68d-5d4b6a5e1803)
![image](https://github.com/user-attachments/assets/7ae709c5-63c4-4ea2-a718-c4e7e789db53)

### Before

![image](https://github.com/user-attachments/assets/7335bbae-2510-4f11-8997-39364a7c9e71)

### After

![image](https://github.com/user-attachments/assets/33b3e882-da33-44d0-8631-7424aa8e5385)

### Before

![image](https://github.com/user-attachments/assets/f00aa79a-326a-4121-b9f8-11cb5fb82da3)

### After

![image](https://github.com/user-attachments/assets/71fae384-3943-41d4-ae11-c9a3bb89a33b)
