### PR TITLE
Make nav menu dropdown animation snappier

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -54,6 +54,9 @@ strong {
 
 html {
   scrollbar-gutter: stable;
+
+  /* Be sure to also set animationSpeed in main.js so it matches this */
+  --animation-speed: 1.0;
 }
 
 .nav-container {
@@ -104,8 +107,8 @@ lil-header.expanded .logo {
   so adding some drop shadow to the logo is the next best thing to handle
   cases where the window is short, the menu is scrolled, and menu items
   overlap the logo */
-  transition: filter 0.1s ease;
-  transition-delay: 1s;
+  transition: filter calc(0.1s * var(--animation-speed)) ease;
+  transition-delay: calc(1s * var(--animation-speed));
   filter: drop-shadow(6px 6px 6px rgba(0, 0, 0, 0.6));
 }
 
@@ -126,14 +129,14 @@ lil-header.expanded .logo {
   @apply bg-black;
   height: 4px;
   left: 0;
-  transition: background-color 300ms ease 400ms, transform 300ms ease;
+  transition: background-color calc(300ms * var(--animation-speed)) ease calc(400ms * var(--animation-speed)), transform calc(300ms * var(--animation-speed)) ease;
 }
 
 lil-header.expanded .menu-button__bar {
   transform: translateY(-50%) rotate(45deg);
   background-color: white;
-  transition: background-color 300ms ease 300ms, transform 300ms ease;
-} 
+  transition: background-color calc(300ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed)), transform calc(300ms * var(--animation-speed)) ease;
+}
 
 .menu-button__bar:nth-child(2) {
   transform: translateY(calc(-50% - 8px));
@@ -144,8 +147,8 @@ lil-header.expanded .menu-button .menu-button__bar:nth-child(2) {
 }
 
 lil-header svg {
-  transition: color 300ms ease;
-  transition-delay: 400ms;
+  transition: color calc(300ms * var(--animation-speed)) ease;
+  transition-delay: calc(400ms * var(--animation-speed));
   color: #121212;
 }
 
@@ -155,8 +158,8 @@ lil-header a:hover svg {
 
 lil-header.expanded svg {
   color: white;
-  transition: color 300ms ease;
-  transition-delay: 300ms;
+  transition: color calc(300ms * var(--animation-speed)) ease;
+  transition-delay: calc(300ms * var(--animation-speed));
 }
 
 .nav-menu {
@@ -168,7 +171,7 @@ lil-header.expanded svg {
   top: 0;
   bottom: 0;
   clip-path: inset(0 0 100% 0);
-  transition: clip-path 0.3s ease-out, opacity 0.3s ease-out;
+  transition: clip-path calc(0.3s * var(--animation-speed)) ease-out, opacity calc(0.3s * var(--animation-speed)) ease-out;
   overflow: auto;
   z-index: 1;
 }
@@ -179,7 +182,7 @@ lil-header.expanded svg {
   align-items: center;
   flex-shrink: 0;
   flex-grow: 1;
-  padding-block: 40px  
+  padding-block: 40px
 }
 
 .nav-menu__list {
@@ -209,18 +212,18 @@ lil-header.expanded svg {
   z-index: 0;
   opacity: 0;
   visibility: hidden;
-  transition: opacity 500ms ease 300ms, visibility 500ms ease 300ms;
+  transition: opacity calc(500ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed)), visibility calc(500ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed));
 }
 
 lil-header.expanded .nav-menu__overlay {
   opacity: 1;
   visibility: visible;
-  transition: opacity 500ms ease 300ms, visibility 500ms ease 300ms;
+  transition: opacity calc(500ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed)), visibility calc(500ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed));
 }
 
 lil-header.expanded .nav-menu__inner {
   display: flex;
-  transition: display 500ms ease 300ms
+  transition: display calc(500ms * var(--animation-speed)) ease calc(300ms * var(--animation-speed))
 }
 
 /*.interactive-link {
@@ -277,7 +280,7 @@ lil-header.expanded .nav-menu__inner {
   background-position: 0 100%;
   background-size: 100% 0;
   background-repeat: no-repeat;
-  transition: background-size .2s ease;
+  transition: background-size calc(0.2s * var(--animation-speed)) ease;
 }
 
 .interactive-link:hover, .interactive-link-inline:hover {
@@ -426,7 +429,7 @@ lil-header.expanded .nav-menu__inner {
   border-radius: 36px;
   border: 1.5px solid #121212;
   position: relative;
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable__icon span {
@@ -437,27 +440,27 @@ lil-header.expanded .nav-menu__inner {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable__icon span:nth-child(1) {
   transform: translate(-50%, -50%) rotate(90deg);
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable__toggle:hover .expandable__icon {
   transform: rotate(90deg);
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable.expanded .expandable__icon {
   transform: rotate(90deg);
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable.expanded .expandable__icon span:nth-child(2) {
   transform: translate(-50%, -50%) rotate(-90deg);
-  transition: transform 300ms ease;
+  transition: transform calc(300ms * var(--animation-speed)) ease;
 }
 
 .expandable__content {
@@ -477,7 +480,7 @@ lil-header.expanded .nav-menu__inner {
 }
 
 html.is-changing .transition-main {
-  transition: opacity 350ms ease-in-out;
+  transition: opacity calc(350ms * var(--animation-speed)) ease-in-out;
 }
 
 html.is-animating .transition-main {
@@ -490,7 +493,7 @@ html.is-animating .transition-main {
     margin-bottom: 36px;
     padding-top: 60px;
   }
-  
+
   .page-hero__subtitle {
     font-size: 28px;
   }
@@ -523,12 +526,12 @@ html.is-animating .transition-main {
     width: 40px;
     height: 40px;
   }
-  
+
   .menu-button__bar {
     transform: translateY(calc(-50% + 6px)) rotate(0deg);
     height: 3px;
   }
-  
+
   .menu-button__bar:nth-child(2) {
     transform: translateY(calc(-50% - 6px));
   }
@@ -540,7 +543,7 @@ html.is-animating .transition-main {
   .label-value .value {
     font-size: 18px;
   }
-  
+
   .nav-menu__list {
     width: 100%;
     display: flex;
@@ -558,7 +561,7 @@ html.is-animating .transition-main {
 /*  .interactive-link {
     text-decoration: underline;
   }
-  
+
   .interactive-link:after {
     display: none;
   }*/

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -56,7 +56,7 @@ html {
   scrollbar-gutter: stable;
 
   /* Be sure to also set animationSpeed in main.js so it matches this */
-  --animation-speed: 1.0;
+  --animation-speed: 0.3;
 }
 
 .nav-container {

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -157,7 +157,7 @@ class LilHeader extends HTMLElement {
         super();
 
         // Be sure to also set --animation-speed in main.css so it matches this
-        this.animationSpeed = 1.0;
+        this.animationSpeed = 0.3;
 
         this.expanded = false;
         this.menuButton = this.querySelector('.menu-button');

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -43,15 +43,15 @@ class jekyllSearch {
       this.resultsSummary = document.querySelector(resultsSummary)
       this.clearButton = document.querySelector(clearButton)
       this.form = form
-  
+
       this.displayResults = this.displayResults.bind(this)
     }
-  
+
     fetchedData() {
       return fetch(this.dataSource)
         .then(blob => blob.json())
     }
-  
+
     async findResults() {
       const data = await this.fetchedData()
       return data.filter(item => {
@@ -60,7 +60,7 @@ class jekyllSearch {
         return (title && title.match(regex)) || item.content.match(regex)
       })
     }
-  
+
     async displayResults() {
       const results = await this.findResults()
       const cycler = createCycler(1,6);
@@ -99,7 +99,7 @@ class jekyllSearch {
         window.history.pushState('', '', url);
         this.searchField.focus()
     }
-  
+
     init() {
       const url = new URL(document.location)
       if (url.searchParams.get("search")) {
@@ -150,11 +150,15 @@ class LilSearch extends HTMLElement {
         this.search.init();
     }
 }
-  
+
 
 class LilHeader extends HTMLElement {
     constructor() {
         super();
+
+        // Be sure to also set --animation-speed in main.css so it matches this
+        this.animationSpeed = 1.0;
+
         this.expanded = false;
         this.menuButton = this.querySelector('.menu-button');
         this.overlay = this.querySelector('.nav-menu__overlay');
@@ -222,7 +226,7 @@ class LilHeader extends HTMLElement {
         gsap.to(this.menu, {duration: 0, display: 'flex'})
 
         gsap.to(this.menu, {
-            duration: safeDuration(0.95),
+            duration: safeDuration(0.95 * this.animationSpeed),
             ease: 'expo.inOut',
             clipPath: 'inset(0% 0% 0% 0%)',
         })
@@ -231,28 +235,28 @@ class LilHeader extends HTMLElement {
             opacity: 0,
             y: -80,
         }, {
-            duration: safeDuration(1.2),
+            duration: safeDuration(1.2 * this.animationSpeed),
             ease: 'power3.out',
             opacity: 1,
             y: 0,
-            stagger: 0.03,
+            stagger: 0,
         })
 
         gsap.fromTo('.nav-menu__socials', {
             opacity: 0,
             y: -10,
         }, {
-            duration: safeDuration(1),
+            duration: safeDuration(1 * this.animationSpeed),
             ease: 'power3.out',
             opacity: 1,
-            delay: 0.55,
+            delay: 0.55 * this.animationSpeed,
             y: 0,
         })
     }
 
     menuCloseAnimation() {
         gsap.to(this.menu, {
-            duration: safeDuration(0.8),
+            duration: safeDuration(0.8 * this.animationSpeed),
             ease: 'expo.inOut',
             clipPath: 'inset(0% 0% 100% 0%)',
         })
@@ -261,24 +265,24 @@ class LilHeader extends HTMLElement {
             opacity: 1,
             y: 0,
         }, {
-            duration: safeDuration(0.4),
+            duration: safeDuration(0.4 * this.animationSpeed),
             ease: 'power3.in',
             opacity: 0,
             y: -30,
-            stagger: 0.001,
+            stagger: 0,
         })
 
         gsap.fromTo('.nav-menu__socials', {
             opacity: 1,
             y: 0,
         }, {
-            duration: safeDuration(0.4),
+            duration: safeDuration(0.4 * this.animationSpeed),
             ease: 'power3.in',
             opacity: 0,
             y: -40,
         })
 
-        gsap.to(this.menu, {duration: safeDuration(0.6), display: 'none'})
+        gsap.to(this.menu, {duration: safeDuration(0.6 * this.animationSpeed), display: 'none'})
     }
 }
 


### PR DESCRIPTION
The current nav menu dropdown animation is a bit slow, and impedes getting around the site. However, modifying the animation as a whole is tricky since the transition rates, delays, and other logic are spread out in a number of CSS rules and JS functions.

This branch adds an animation speed modifier variable in both `main.js` and `main.css` so we can easily change the dropdown animation in one (well, two) place(s). If `animationSpeed` and `--animation-speed` are set to `1.0`, the menu dropdown animates at the (current) relatively slow speed.

I have set it to `0.3`, which seems to make for a smoother and snappier experience.