### PR TITLE
Various fixes to redesign typography

### DIFF
--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -1,6 +1,6 @@
 <div class="relative block container {% if include.featured %}pt-84 tbl:pt-120 md:pt-84{% endif %}">
   {% if include.featured %}
-    <div class="absolute w-72 h-72 tbl:w-136 tbl:h-136 md:w-165 md:h-165 top-48 left-12 sm:left-0 tbl:top-52 md:top-0 z-[2] motion-safe:animate-spin">
+    <div class="absolute w-72 h-72 tbl:w-136 tbl:h-136 md:w-165 md:h-165 top-48 left-12 sm:left-0 tbl:top-52 md:top-0 z-[2] motion-safe:animate-spin select-none">
       <img src="{{ site.baseurl }}/assets/images/featured-project-text.svg" class="w-full h-full object-contain" alt="Featured Project" />
     </div>
   {% endif %}

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -10,7 +10,7 @@ custom-css: ['blog-search']
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}
     <div class="flex flex-col gap-32 pb-40 border-b-1 border-black">
-      <h1 class="h1">Blog</h1>
+      <h1 class="page-hero__title">Blog</h1>
       {% include blog-search.html %}
     </div>
   </div>

--- a/app/_posts/2024-06-10-can-llms-generate-compelling-case-briefs.md
+++ b/app/_posts/2024-06-10-can-llms-generate-compelling-case-briefs.md
@@ -6,7 +6,8 @@ tags:
 - ai research
 ---
 
-> The Library Innovation Lab welcomes a range of research assistants and fellows to our team to conduct independently-driven research which intersects in some way to our core work.<br>
+> The Library Innovation Lab welcomes a range of research assistants and fellows to our team to conduct independently-driven research which intersects in some way to our core work.
+
 > The following is a reflection written by [Chris Shen](/about/#chris-shen), a Research Assistant who collaborated with members of LIL in the spring semester of 2024. Chris is a sophomore at Harvard College studying Statistics and Government.
 
 From poetry to Python, LLMs have the potential to drastically influence human productivity. Could AI also revolutionize legal education and streamline case understanding? 

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -330,14 +330,14 @@ lil-header.expanded .nav-menu__inner {
 }
 
 .page-hero__title {
-  font-size: clamp(52px, 12vw, 140px);
+  font-size: clamp(52px, 12vw, 84px);
   font-weight: 500;
   line-height: 100%;
   padding-bottom: 36px;
 }
 
 .page-hero__subtitle {
-  font-size: 48px;
+  font-size: 36px;
   line-height: 120%;
   max-width: 950px;
 }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -190,7 +190,7 @@ lil-header.expanded svg {
   display: grid;
   grid-template-columns: repeat(2, minmax(min(100%, 300px), 1fr));
   gap: 15px;
-  font-size: clamp(24px, 5vw, 90px);
+  font-size: clamp(24px, 5vw, 84px);
   line-height: 1;
   font-weight: 500;
 }

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -418,6 +418,7 @@ lil-header.expanded .nav-menu__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  cursor: pointer;
 }
 
 .expandable__toggle--title {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -357,8 +357,12 @@ lil-header.expanded .nav-menu__inner {
 }
 
 .page-hero.project .page-hero__title {
-  margin-left: -8px;
   padding-bottom: 16px;
+}
+
+/* Align large heading text flush with left side of page content */
+.page-hero__title {
+  margin-left: -0.05em;
 }
 
 .page-hero.events {

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -280,7 +280,7 @@ lil-header.expanded .nav-menu__inner {
   background-position: 0 100%;
   background-size: 100% 0;
   background-repeat: no-repeat;
-  transition: background-size calc(0.2s * var(--animation-speed)) ease;
+  transition: background-size 0.2s ease;
 }
 
 .interactive-link:hover, .interactive-link-inline:hover {

--- a/app/assets/css/post-content.css
+++ b/app/assets/css/post-content.css
@@ -110,3 +110,7 @@
 .post-content a:hover {
   background-size: 100% 0;
 }
+
+.post-content blockquote {
+  margin: 0.5em 0 1em 2em;
+}

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -12,7 +12,7 @@ custom-css: ['blog-search']
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}
     <div class="flex flex-col gap-32 pb-40 border-b-1 border-black">
-      <h1 class="h1">Blog</h1>
+      <h1 class="page-hero__title">Blog</h1>
       {% include blog-search.html %}
     </div>
   </div>

--- a/app/index.html
+++ b/app/index.html
@@ -33,7 +33,7 @@ sharing-card-type: summary_large_image
 <div class="container flex flex-col gap-50 md:gap-100">
   <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48">
     <h2 class="h2">Who We Are</h2>
-    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
+    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20 z-10">
       <div class="flex flex-col gap-20">
         <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research that empowers access to our shared knowledge and cultural heritage.</p>
       </div>

--- a/app/index.html
+++ b/app/index.html
@@ -8,9 +8,7 @@ sharing-card-type: summary_large_image
 ---
 
 <div class="pt-36 pb-32 sm:pt-96 sm:pb-132  md:pt-156 md:pb-228 max-w-[92%] sm:max-w-[88%] xl:max-w-[1190px] m-auto text-[clamp(52px,8.5vw,120px)] leading-[clamp(52px,8.5vw,120px)] sm:text-center">
-  <h1>
-    <strong>Library Innovation Lab</strong> at <strong>Harvard Law School</strong>
-  </h1>
+  <h1 class="font-medium">Library Innovation Lab at Harvard Law School</h1>
 </div>
 
 <div class="bg-black text-white w-full py-48 md:pt-72 md:pb-120 continer text-center flex flex-col justify-center items-center gap-20 md:gap-32">


### PR DESCRIPTION
This makes a number of small-to-medium fixes and edits to typography on the redesigned website. Changes include the following:

* Made headings more uniform in terms of CSS class usage and size across pages
* Reduced some heading/subheading class sizes for readability
* Tweaked flush left alignment of project page headings to use ems instead of pixels
* Reduced maximum nav menu font size so it doesn't exceed the max heading font size on the page
* Fixed a bug wherein the "Learn More About Who We Are" link on the homepage was partly unclickable because it was masked by the Z-index of the following element
* Added CSS styling for `blockquote` elements on blog posts since Tailwind strips it
  + Note: I searched the blog posts for any other elements that might not be displaying properly, but everything else seems to look OK: `iframe`, `img`, `figure`, `figcaption`, etc.
* We now display cursor as a pointer when hovering over clickable accordion sections on the Careers page
* Prevented inadvertent user selection of "Featured Project" spinner on homepage