### PR TITLE
Various fixes to redesign whitespace and alignment issues

### DIFF
--- a/app/_includes/footer.html
+++ b/app/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 {% unless page.slug == 'our-work' %} mt-[theme(footerPadding.sm)] md:mt-[theme(footerPadding.md)] {% endunless %}">
+<footer aria-label="page footer" class="bg-black text-white pt-24 pb-24 sm:pt-60 sm:pb-40 {% unless page.slug == 'our-work' or page.slug == 'jobs' %} mt-[theme(footerPadding.sm)] md:mt-[theme(footerPadding.md)] {% endunless %}">
   <div class="nav-container flex flex-wrap sm:grid sm:grid-cols-12 sm:gap-x-20 sm:gap-y-26">
     <a href="/" class="block relative w-full max-w-[160px] sm:col-span-4 sm:max-w-[340px]">
       <span class="sr-only">Home</span>
@@ -46,4 +46,3 @@
     </div>
   </div>
 </footer>
-

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -17,7 +17,7 @@ layout: default
   <section class="container flex flex-col gap-36 md:gap-72">
     <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
       <h2 class="h2">Where can I find {{page.title}}?</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-12 pt-20 xl:max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-12 xl:max-w-[700px]">
         {% if page.project_website %}
           {% include arrow-link.html label=page.project_website href=page.project_website target="_blank" %}
         {% endif %}
@@ -29,7 +29,7 @@ layout: default
     {% if page.why_does_it_exist %}
       <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
         <h2 class="h2">Why does {{page.title}} exist?</h2>
-        <div class="md:col-span-2 body-text flex flex-col gap-20 pt-20 xl:max-w-[700px]">
+        <div class="md:col-span-2 body-text flex flex-col gap-20 xl:max-w-[700px]">
           {{ page.why_does_it_exist | markdownify }}
         </div>
       </div>
@@ -62,13 +62,13 @@ layout: default
       </div>
     </section>
   {% endif %}
-  
+
   {% if page.who_contributed %}
     <section class="container">
       <div class="flex flex-col lg:grid lg:grid-cols-3 gap-24 lg:gap-36">
         <h2 class="h2">Project Contributors</h2>
 
-        <div class="slice-body additional-contributors lg:col-span-2 lg:pt-20 body-text lg:max-w-[750px]">
+        <div class="slice-body additional-contributors lg:col-span-2 body-text lg:max-w-[750px]">
           {% for name in page.who_contributed %}
             {% assign person = site.data.people[name] %}
             <strong class="name">{{ person.name }}</strong>
@@ -78,5 +78,5 @@ layout: default
       </div>
     </section>
   {% endif %}
-  
+
 </div>

--- a/app/_layouts/tag_or_category.html
+++ b/app/_layouts/tag_or_category.html
@@ -5,7 +5,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80">
+<section class="pt-48 md:pt-72">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -17,7 +17,7 @@ layout: default
   <section class="container md:mb-12">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
       <h2 class="h2">Who We Are</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-24 md:pt-20 max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-24 max-w-[700px]">
         <p>We are a team of librarians, technologists, lawyers, designers, and more, and we work out of the Harvard Law School Library.</p>
         <p>We believe that libraries play a fundamental role in humanity as open, privacy-respecting, and sustainable information spaces. We also believe technology holds great power to break down barriers to information creation, preservation, and use.</p>
       </div>

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -325,7 +325,7 @@ lil-header.expanded .nav-menu__inner {
 .page-hero {
   padding-bottom: 72px;
   border-bottom: 1px solid #121212;
-  margin-bottom: 60px;
+  margin-bottom: 72px;
   padding-top: 120px;
 }
 
@@ -367,6 +367,14 @@ lil-header.expanded .nav-menu__inner {
 
 .page-hero.events .page-hero__title {
   padding-bottom: 72px;
+}
+
+.our_work .page-hero {
+  padding-bottom: 72px;
+}
+
+.our_work .page-hero__title {
+  padding-bottom: 0;
 }
 
 .body-text, .expandable__content {

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -7,7 +7,7 @@ pagination:
 custom-css: ['blog-search']
 ---
 
-<section class="pt-40 md:pt-80">
+<section class="pt-48 md:pt-72">
 
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}

--- a/app/events.html
+++ b/app/events.html
@@ -38,7 +38,7 @@ layout: default
           <div class="label">Next Event</div>
           <div class="flex flex-col md:grid md:grid-cols-3 md:gap-36 pb-36 md:pb-48">
             <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
-            <div class="md:col-span-2 body-text md:max-w-[700px] pt-20 flex flex-col items-start gap-20">
+            <div class="md:col-span-2 body-text md:max-w-[700px] flex flex-col items-start gap-20">
               {{ next_event.excerpt }}
               {% capture linkLabel %}
                 <span class="sr-only">{{ next_event.title }},</span> More Info

--- a/app/index.html
+++ b/app/index.html
@@ -35,7 +35,7 @@ sharing-card-type: summary_large_image
 <div class="container flex flex-col gap-50 md:gap-100">
   <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48">
     <h2 class="h2">Who We Are</h2>
-    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
+    <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
       <div class="flex flex-col gap-20">
         <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research that empowers access to our shared knowledge and cultural heritage.</p>
       </div>
@@ -72,7 +72,7 @@ sharing-card-type: summary_large_image
   <div class="container flex flex-col gap-50 md:gap-100">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black">
       <h2 class="h2">Our Work</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
+      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
         <div class="flex flex-col gap-20">
           <p>Platforms like Perma.cc translate the traditional roles of libraries into the digital age. Explorations like warcGPT empower practitioners to learn and leverage new technologies in the context of their field.</p>
         </div>

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -27,7 +27,7 @@ layout: default
     </figure>
   </section>
 
-  <section class="container flex flex-col gap-24 md:gap-40">
+  <section class="container flex flex-col gap-24 md:gap-40{% if site.jobs.size == 0 %} pb-66{% endif %}">
     <h2 class="h2">Background</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
@@ -41,7 +41,7 @@ layout: default
 
   {% assign staff_sections = site.jobs | where:"category","staff" | sort: "order" %}
   {% if staff_sections.size > 0 %}
-  <section class="container flex flex-col gap-24 md:gap-40">
+  <section class="container flex flex-col gap-24 md:gap-40{% if staff_sections.size == site.jobs.size %} pb-66{% endif %}">
     <h2 class="h2">Staff Positions</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
@@ -55,7 +55,7 @@ layout: default
 
   {% assign research_sections = site.jobs | where:"category","research" | sort: "order" %}
   {% if research_sections.size > 0 %}
-  <section class="container flex flex-col gap-24 md:gap-40">
+  <section class="container flex flex-col gap-24 md:gap-40 pb-66">
     <h2 class="h2">Research Positions</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -59,7 +59,7 @@ layout: default
   <section class="container pb-36">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
       <h2 class="h2">Platforms</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-18">
+      <div class="md:col-span-2 body-text flex flex-col gap-50">
         <p class="flex flex-col gap-20 max-w-[700px]">
           Tools are the heart of the Library Innovation Lab. We build things. Our platforms each have their own user base and long-term goals.
         </p>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -90,7 +90,7 @@ layout: default
     {% endfor %}
   </section>
 
-  <section class="bg-yellow pt-48 tbl:pt-72 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.md)] ">
+  <section class="bg-yellow pt-48 tbl:pt-72 pb-[theme(footerPadding.sm)] md:pb-[theme(footerPadding.md)] md:mt-48">
     <div class="container flex flex-col gap-12 md:gap-24">
       <h2 class="h2">Past Projects</h2>
       <div class="flex flex-col">


### PR DESCRIPTION
This makes several fixes to whitespace and alignment issues on the redesigned website, including the following:

* Fixed inconsistent and sometimes odd-looking top margin/padding on right-hand text blocks; they now line up vertically with their associated headings to the left
* Fixed the bottom padding on the Careers page so it is consistent with the bottom padding on Our Work and similar pages (sorry, this involves some ugly conditionals; we can take it out if it's too gross)
* Ensured uniform top padding across blog page layouts: main blog listing/search results, tag/category listing, blog post
* Removed extraneous and inconsistent heading padding on pages for individual projects