### PR TITLE
Restore baseline alignment for right-side text blocks

### DIFF
--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -17,7 +17,7 @@ layout: default
   <section class="container flex flex-col gap-36 md:gap-72">
     <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
       <h2 class="h2">Where can I find {{page.title}}?</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-12 xl:max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-12 pt-20 xl:max-w-[700px]">
         {% if page.project_website %}
           {% include arrow-link.html label=page.project_website href=page.project_website target="_blank" %}
         {% endif %}
@@ -29,7 +29,7 @@ layout: default
     {% if page.why_does_it_exist %}
       <div class="flex flex-col xl:grid xl:grid-cols-3 xl:gap-48">
         <h2 class="h2">Why does {{page.title}} exist?</h2>
-        <div class="md:col-span-2 body-text flex flex-col gap-20 xl:max-w-[700px]">
+        <div class="md:col-span-2 body-text flex flex-col gap-20 pt-20 xl:max-w-[700px]">
           {{ page.why_does_it_exist | markdownify }}
         </div>
       </div>
@@ -62,13 +62,13 @@ layout: default
       </div>
     </section>
   {% endif %}
-
+  
   {% if page.who_contributed %}
     <section class="container">
       <div class="flex flex-col lg:grid lg:grid-cols-3 gap-24 lg:gap-36">
         <h2 class="h2">Project Contributors</h2>
 
-        <div class="slice-body additional-contributors lg:col-span-2 body-text lg:max-w-[750px]">
+        <div class="slice-body additional-contributors lg:col-span-2 lg:pt-20 body-text lg:max-w-[750px]">
           {% for name in page.who_contributed %}
             {% assign person = site.data.people[name] %}
             <strong class="name">{{ person.name }}</strong>
@@ -78,5 +78,5 @@ layout: default
       </div>
     </section>
   {% endif %}
-
+  
 </div>

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -17,7 +17,7 @@ layout: default
   <section class="container md:mb-12">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40">
       <h2 class="h2">Who We Are</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-24 max-w-[700px]">
+      <div class="md:col-span-2 body-text flex flex-col gap-24 md:pt-20 max-w-[700px]">
         <p>We are a team of librarians, technologists, lawyers, designers, and more, and we work out of the Harvard Law School Library.</p>
         <p>We believe that libraries play a fundamental role in humanity as open, privacy-respecting, and sustainable information spaces. We also believe technology holds great power to break down barriers to information creation, preservation, and use.</p>
       </div>

--- a/app/events.html
+++ b/app/events.html
@@ -38,7 +38,7 @@ layout: default
           <div class="label">Next Event</div>
           <div class="flex flex-col md:grid md:grid-cols-3 md:gap-36 pb-36 md:pb-48">
             <h1 class="h2">{{ next_event.title }} - {{ next_event.date_informal }}</h1>
-            <div class="md:col-span-2 body-text md:max-w-[700px] flex flex-col items-start gap-20">
+            <div class="md:col-span-2 body-text md:max-w-[700px] pt-20 flex flex-col items-start gap-20">
               {{ next_event.excerpt }}
               {% capture linkLabel %}
                 <span class="sr-only">{{ next_event.title }},</span> More Info

--- a/app/index.html
+++ b/app/index.html
@@ -70,7 +70,7 @@ sharing-card-type: summary_large_image
   <div class="container flex flex-col gap-50 md:gap-100">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black">
       <h2 class="h2">Our Work</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
+      <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 md:pt-20">
         <div class="flex flex-col gap-20">
           <p>Platforms like Perma.cc translate the traditional roles of libraries into the digital age. Explorations like WARC-GPT empower practitioners to learn and leverage new technologies in the context of their field.</p>
         </div>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -59,7 +59,7 @@ layout: default
   <section class="container pb-36">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40">
       <h2 class="h2">Platforms</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-50">
+      <div class="md:col-span-2 body-text flex flex-col gap-50 md:pt-18">
         <p class="flex flex-col gap-20 max-w-[700px]">
           Tools are the heart of the Library Innovation Lab. We build things. Our platforms each have their own user base and long-term goals.
         </p>


### PR DESCRIPTION
Per our discussion about how to align our right-side text blocks relative to their left-side headings, this restores our previous use of baseline alignment by reverting commit 622f060bc4f17cdf619f07e577526c9d9397e3b0 from PR https://github.com/harvard-lil/website-static/pull/630.

Note for posterity: It seems like the ideal way to achieve baseline alignment would be via CSS `align-items: baseline` or the associated [Tailwind class](https://tailwindcss.com/docs/align-items#baseline). However, after experimenting a bit, I don't think this will work easily for our blocks  — too much nested stuff. For now, seems like the hand-tuned `pt-20` approach is the way to go.