### PR TITLE
Fix hiring marquee display bug; add SSE job listing

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -1,6 +1,6 @@
 <lil-header class="block relative z-header">
   {% if page.slug == "home" %}
-    {% include hiring-banner.html title="" %}
+    {% include hiring-banner.html title="Senior Software Engineer" %}
   {% endif %}
   <header class="pt-24 md:pt-36 nav-container">
     <div class="flex items-center justify-between">

--- a/app/_includes/hiring-banner.html
+++ b/app/_includes/hiring-banner.html
@@ -1,4 +1,4 @@
-{% if include.title.size > 0%}
+{% if include.title.size > 0 %}
 <lil-marquee class="block marquee bg-purple py-6 md:py-10 px-20 uppercase font-mono text-14 md:text-16 leading-120 tracking-[0.02em] md:tracking-[0.07em] text-announcement whitespace-nowrap overflow-hidden relative z-[100]">
   <a href="{{ site.baseurl }}/jobs/" class="marquee__inner">
     <div class="marquee__part inline-block">* We’re hiring — {{ include.title }} </div>

--- a/app/_jobs/senior_software_engineer.md
+++ b/app/_jobs/senior_software_engineer.md
@@ -1,0 +1,8 @@
+---
+title: Senior Software Engineer — Full Stack
+category: staff
+order: 1
+---
+As a member of our engineering team, the Senior Software Engineer will work across our various tools, applications, and experiments to fulfill LIL’s mission to bring library principles to technological frontiers. The ideal candidate will have experience building performant, testable, maintainable, and fault-tolerant products and tools at scale, for audiences both technical and non-technical.
+
+To apply: <a href="https://sjobs.brassring.com/TGnewUI/Search/Home/Home?partnerid=25240&siteid=5341#jobDetails=2011857_5341" class="interactive-link dark reverse">Application form</a>. In addition to Harvard’s standard application form, please provide a short cover letter explaining how your career trajectory and interests align with our work and mission.

--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -382,6 +382,17 @@ function setupSwup() {
           event.url?.contains('blog') || event.state?.source !== 'swup'
         },
     });
+
+    const lilMarqueeHandler = (visit) => {
+      let isHomepage = visit.to.url === '/';
+      let elements = document.getElementsByTagName('lil-marquee');
+      Array.from(elements).map(element => {
+        isHomepage ? element.classList.remove('hidden') : element.classList.add('hidden');
+      });
+    };
+
+    // Register handler to hide marquee if user navigates away from homepage
+    swup.hooks.on('content:replace', lilMarqueeHandler);
 }
 
 const setup = () => {


### PR DESCRIPTION
This addresses the bug discussed in LIL-2655, wherein the "we're hiring" marquee banner persists if you start at the homepage and navigate away, but doesn't appear at all if you start on another page. I added a [Swup hook](https://swup.js.org/hooks/) that reproduces the old website behavior: display the marquee on the homepage, hide it elsewhere.

To close the loop on https://github.com/harvard-lil/website-static/pull/634, I also added the new SSE job posting to the redesign.