### PR TITLE
Correct section name.

### DIFF
--- a/app/_data/people.yaml
+++ b/app/_data/people.yaml
@@ -239,7 +239,7 @@ matteo-cargnelutti:
   image: matteo-cargnelutti.jpg
   affiliated: true
   current: true
-  section: Affiliates
+  section: Fellows
 
 jim-cowie:
   name: Jim Cowie


### PR DESCRIPTION
In the redesign, there is a separate "Fellows" section; there is no longer an "Affiliates" section.