### PR TITLE
Add JS cache-buster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           LIVE_SITE: ${{ secrets.LIVE_SITE }}
         run: |
           set -x
-          CSS_BUST=$(find build/assets/css -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://$LIVE_SITE/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
+          CSS_BUST=$(find build/assets/css build/*.config.js -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://$LIVE_SITE/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
           if [[ $CSS_BUST ]] ; then
               COUNTER=`grep css-cache-buster app/_layouts/default.html | sed -r 's/.*css-cache-buster=([0-9]+).*/\1/'`
               let NEWCOUNTER=$COUNTER+1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,15 +47,27 @@ jobs:
           set -x
           CSS_BUST=$(find build/assets/css -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://$LIVE_SITE/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
           if [[ $CSS_BUST ]] ; then
-              COUNTER=`grep cache-buster app/_layouts/default.html | sed -r 's/.*cache-buster=([0-9]+).*/\1/'`
+              COUNTER=`grep css-cache-buster app/_layouts/default.html | sed -r 's/.*css-cache-buster=([0-9]+).*/\1/'`
               let NEWCOUNTER=$COUNTER+1
-              perl -pi -e "s/cache-buster=$COUNTER/cache-buster=$NEWCOUNTER/" app/_layouts/default.html
-              perl -pi -e "s/cache-buster=$COUNTER/cache-buster=$NEWCOUNTER/" app/_includes/custom-css.html
+              perl -pi -e "s/css-cache-buster=$COUNTER/css-cache-buster=$NEWCOUNTER/" app/_layouts/default.html
+              perl -pi -e "s/css-cache-buster=$COUNTER/css-cache-buster=$NEWCOUNTER/" app/_includes/custom-css.html
               git config user.email "lil@law.harvard.edu"
               git config user.name "GitHub Actions"
               git add app/_layouts/default.html app/_includes/custom-css.html
               git commit -m 'Increment CSS cache-buster [skip ci]'
-              git push origin redesign || exit 1
+              git push origin develop || exit 1
+          fi
+          JS_BUST=$(find build/assets/javascripts -type f -exec bash -c 'if [[ `diff {} <(curl -s "https://$LIVE_SITE/$(echo "{}" | cut -c 7-)")` ]]; then echo "bust ({})"; fi' \;)
+          if [[ $JS_BUST ]] ; then
+              COUNTER=`grep js-cache-buster app/_layouts/default.html | sed -r 's/.*js-cache-buster=([0-9]+).*/\1/'`
+              let NEWCOUNTER=$COUNTER+1
+              perl -pi -e "s/js-cache-buster=$COUNTER/js-cache-buster=$NEWCOUNTER/" app/_layouts/default.html
+              perl -pi -e "s/js-cache-buster=$COUNTER/js-cache-buster=$NEWCOUNTER/" app/_includes/custom_scripts.html
+              git config user.email "lil@law.harvard.edu"
+              git config user.name "GitHub Actions"
+              git add app/_layouts/default.html app/_includes/custom-scripts.html
+              git commit -m 'Increment JS cache-buster [skip ci]'
+              git push origin develop || exit 1
           fi
           export DEPLOY_CONTENT='{"GITHUB_RUN_NUMBER":"'$GITHUB_RUN_NUMBER'","GITHUB_SHA":"'$GITHUB_SHA'","GITHUB_REF":"'$GITHUB_REF'","GITHUB_REPOSITORY":"'$GITHUB_REPOSITORY'","GITHUB_ACTOR":"'$GITHUB_ACTOR'"}' ;
           export DEPLOY_SIG="sha1=`echo -n "$DEPLOY_CONTENT" | openssl sha1 -hmac $DEPLOY_KEY | sed 's/^.* //'`" ;

--- a/app/_includes/custom-css.html
+++ b/app/_includes/custom-css.html
@@ -1,10 +1,10 @@
 {% if layout.custom-css %}
   {% for file in layout.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?cache-buster=52">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?css-cache-buster=52">
   {% endfor %}
 {% endif %}
 {% if page.custom-css %}
   {% for file in page.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?cache-buster=52">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?css-cache-buster=52">
   {% endfor %}
 {% endif %}

--- a/app/_includes/custom-scripts.html
+++ b/app/_includes/custom-scripts.html
@@ -1,5 +1,5 @@
 {% if page.custom-scripts %}
   {% for file in page.custom-scripts %}
-    <script src="{{ site.baseurl }}/assets/javascripts/{{ file | strip }}"></script>
+    <script src="{{ site.baseurl }}/assets/javascripts/{{ file | strip }}?js-cache-buster=1"></script>
   {% endfor %}
 {% endif %}

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -12,7 +12,7 @@
     <link rel="icon" href="{{ site.baseurl }}/assets/images/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/images/apple-touch-favicon.png">
     <link rel="manifest" href="{{ site.baseurl }}/manifest.webmanifest">
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?cache-buster=52">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?css-cache-buster=52">
     <link rel="alternate" href="{{ site.baseurl }}/blog/feed/" type="application/rss+xml" title="RSS Feed">
     <script src="{{ site.baseurl }}/assets/lib/gsap@3.12.5/gsap.min.js"></script>
     <script src="{{ site.baseurl }}/assets/lib/swup@4.7.0/Swup.umd.js"></script>
@@ -27,7 +27,7 @@
       </main>
       {% include footer.html %}
     </div>
-    <script src="{{ site.baseurl }}/assets/javascripts/main.js"></script>
+    <script src="{{ site.baseurl }}/assets/javascripts/main.js?js-cache-buster=1"></script>
     {% include custom-scripts.html %}
   </body>
 </html>


### PR DESCRIPTION
This is a first cut at a JS cache-buster, along the lines of our existing CSS cache-busting mechanism. It renames the CSS cache-buster to distinguish it from this one. It also corrects the branch name, which I failed to update in #647.

I think it's not necessary to handle files in `build/assets/lib/`, as they're versioned. TBD: should we handle the JS in the century-scale storage article? `build/postcss.config.js` and `build/tailwind.config.js`?