### PR TITLE
Fix swup-related page heading whitespace issues

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -22,7 +22,7 @@
   <body class="bg-white font-sans font-normal">
     {% include header.html %}
     <div id="swup" class="transition-main">
-      <main class="{{ page.type }} {{ page.slug }}">
+      <main class="{{- page.type }} {{ page.slug -}}">
         {{ content }}
       </main>
       {% include footer.html %}

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -19,10 +19,10 @@
     <script src="{{ site.baseurl }}/assets/lib/swup-head-plugin@2.2.0/index.umd.js"></script>
     {% include custom-css.html %}
   </head>
-  <body class="{{ page.type }} {{ page.slug }} bg-white font-sans font-normal">
+  <body class="bg-white font-sans font-normal">
     {% include header.html %}
     <div id="swup" class="transition-main">
-      <main>
+      <main class="{{ page.type }} {{ page.slug }}">
         {{ content }}
       </main>
       {% include footer.html %}


### PR DESCRIPTION
See LIL-2978. Some `h1.page-hero__title` page headings on the website have weirdly inconsistent amounts of `padding-bottom` depending on whether the page is the first one you load or one you navigate to via another page (i.e., via swup transitions).

The root issue is that `page.type` and `page.slug` get programmatically plugged into the class list of `body`, but because `body` is outside the swup container, `page.type` and `page.slug` don't get updated when navigating to other pages. This branch fixes the issue by relocating `page.type` and `page.slug` classes to the `main` element inside `div#swup`.

Everything seems good on my end, but it's probably worth double-checking that the various layout types still look normal.