### PR TITLE
First pass: accessible tooltip citations.

### DIFF
--- a/app/century-scale-storage/index.html
+++ b/app/century-scale-storage/index.html
@@ -321,10 +321,13 @@
                 <p>
                     Only three RAMAC 305 systems and seven individual 350 disk drives in various configurations are
                     known to have survived. A complete mechanical assembly of a 350 drive was restored in 2002 and sits
-                    in the collection of the Computer History Museum. According to a 2014 <a
-                        href="https://www.wired.com/2014/01/tech-time-warp-ibm-ramac/" class="footnote-link"
-                        target="_blank"><em>Wired</em> magazine report<cite><em>Tech
-                                Time Warp of the Week: The World's First Hard Drive, 1956</em> (Wired, 2014)</cite></a>,
+                    in the collection of the Computer History Museum. According to a 2014
+                    <a href="https://www.wired.com/2014/01/tech-time-warp-ibm-ramac/"
+                       class="footnote-link" target="_blank"><em>Wired</em> magazine report</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Tech Time Warp of the Week: The World's First Hard Drive, 1956</em> (Wired, 2014)
+                    </cite>
                     during that
                     restoration researchers
                     found data still present and readable on the 350, from a Canadian insurance company, car
@@ -385,23 +388,36 @@
                 <p>
                     No single methodology that we discuss holds an obvious answer to this question, and that is fine,
                     particularly because professional archivists recommend making and storing multiple copies of
-                    anything in multiple formats as a best practice. For example, <a
-                        href="https://library.si.edu/research/best-practices-storing-archiving-and-preserving-data"
-                        class="footnote-link" target="_blank">the Smithsonian endorses<cite><em>Best
-                                Practices for Storing, Archiving and
-                                Preserving Data</em> (Smithsonian
-                            Libraries, 2023)</cite></a> a “3-2-1 Rule” when it comes to data
+                    anything in multiple formats as a best practice. For example,
+                    <a href="https://library.si.edu/research/best-practices-storing-archiving-and-preserving-data"
+                       class="footnote-link" target="_blank">the Smithsonian endorses</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Best Practices for Storing, Archiving and Preserving Data</em>
+                        (Smithsonian Libraries, 2023)
+                    </cite>
+                     a “3-2-1 Rule” when it comes to data
                     storage: “3 copies of the data, stored on 2 different media, with at least 1 stored off-site or in
-                    the cloud.” Or as archivist Trevor Owens puts it in his seminal text <a class="footnote-link"
-                        href="https://search.worldcat.org/en/title/1030899528" target="_blank"><em>Theory and Craft of
-                            Digital Preservation</em><cite><em>The Theory and Craft <br>of Digital Preservation</em>
-                            <br>(Trevor Owens, 2018)</cite></a>, “In digital
+                    the cloud.” Or as archivist Trevor Owens puts it in his seminal text
+                    <a class="footnote-link"
+                        href="https://search.worldcat.org/en/title/1030899528" target="_blank">
+                        <em>Theory and Craft of Digital Preservation</em></a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Theory and Craft <br>of Digital Preservation</em>
+                        <br>(Trevor Owens, 2018)
+                    </cite>
+                    “In digital
                     preservation we place our trust in having multiple copies. We cannot trust the durability of digital
                     media, so we need to make multiple copies.” When storing digital data, archivists recommend
-                    utilizing file formats that are widespread and not dependent on a single commercial entity—in <a
-                        href="https://library.si.edu/sites/default/files/tutorial/pdf/fileformats20180305.pdf"
-                        class="footnote-link">the words of the Smithsonian<cite> <em>Smithsonian Data
-                                Management Best Practices</em> <br>(Smithsonian Libraries, 2018)</cite></a>,
+                    utilizing file formats that are widespread and not dependent on a single commercial entity—in
+                    <a href="https://library.si.edu/sites/default/files/tutorial/pdf/fileformats20180305.pdf"
+                        class="footnote-link">the words of the Smithsonian</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Smithsonian Data Management Best Practices</em>
+                        <br>(Smithsonian Libraries, 2018)
+                    </cite>,
                     “non-proprietary, platform-independent, unencrypted, lossless, uncompressed, [and] commonly used.”
                     But at the century scale, even our most widely adopted file formats are completely untested. Digital
                     history is not long enough to definitively settle on best practices.
@@ -597,20 +613,29 @@
             <div>
                 <h2>The Cloud</h2>
                 <p>
-                    Google Drive passed <a
-                        href="https://www.theverge.com/2018/7/25/17613442/google-drive-one-billion-users"
-                        class="footnote-link" target="_blank">one billion users in 2018.<cite><em>Google
-                                Drive is about to hit 1 billion users</em> (The Verge, 2018)</cite></a>
-                    Dropbox currently claims <a
-                        href="https://aem.dropbox.com/cms/content/dam/dropbox/www/en-us/about/company-info/DBX_FactSheet.pdf"
-                        class="footnote-link" target="_blank">700 million registered users.<cite> <em>Fact
-                                Sheet</em> (Dropbox)</cite></a>
-                    According to <a
-                        href="https://www.datacenterdynamics.com/en/news/amazon-web-services-owns-119-million-square-feet-of-property-leases-141-million-square-feet/"
-                        class="footnote-link" target="_blank">a 2022 10-K filing<cite>
-                            <em>Amazon Web Services owns 11.9 million square feet of property, leases 14.1 million
-                                square
-                                feet</em> (Data Center Dynamics, 2022)</cite></a>, Amazon Web Services leases 14 million
+                    Google Drive passed
+                    <a href="https://www.theverge.com/2018/7/25/17613442/google-drive-one-billion-users"
+                        class="footnote-link" target="_blank">
+                        one billion users in 2018.</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Google Drive is about to hit 1 billion users</em> (The Verge, 2018)
+                    </cite>
+                    Dropbox currently claims
+                    <a href="https://aem.dropbox.com/cms/content/dam/dropbox/www/en-us/about/company-info/DBX_FactSheet.pdf"
+                        class="footnote-link" target="_blank">700 million registered users.</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Fact Sheet</em> (Dropbox)
+                    </cite>
+                    According to
+                    <a href="https://www.datacenterdynamics.com/en/news/amazon-web-services-owns-119-million-square-feet-of-property-leases-141-million-square-feet/"
+                        class="footnote-link" target="_blank">a 2022 10-K filing</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Amazon Web Services owns 11.9 million square feet of property, leases 14.1 million square feet</em> (Data Center Dynamics, 2022)
+                    </cite>
+                    Amazon Web Services leases 14 million
                     square feet of real estate and owns
                     close to another 12 million square feet. We live and compute in the cloud’s world. The cloud is the
                     dominant method for how we store data, and how the software that retrieves that data runs. Software
@@ -645,8 +670,11 @@
                 </p>
                 <p>
                     <a href="https://aws.amazon.com/blogs/aws/celebrate-amazon-s3s-17th-birthday-at-aws-pi-day-2023/"
-                        class="footnote-link" target="_blank">According to Amazon<cite>
-                            <em>Celebrate Amazon S3’s 17th birthday at AWS Pi Day 2023</em> (Amazon, 2023)</cite></a>,
+                        class="footnote-link" target="_blank">According to Amazon</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Celebrate Amazon S3’s 17th birthday at AWS Pi Day 2023</em> (Amazon, 2023)
+                    </cite>
                     S3 “holds more than 280 trillion objects and
                     averages over 100 million requests a second. To protect data integrity, Amazon S3 performs over four
                     billion checksum computations per second.” The total of human production under the stewardship of
@@ -660,11 +688,15 @@
                     an internet connection, and part of a massive existing infrastructure with many other stakeholders.
                     This network effect of so many clients gives a sense of security unto itself, not unlike the “too
                     big to fail” culture of banking. If you store your data trove in the same place as massive
-                    investment banks and <a
-                        href="https://www.theatlantic.com/technology/archive/2014/07/the-details-about-the-cias-deal-with-amazon/374632/"
-                        target="_blank" class="footnote-link">the CIA<cite><em>The Details About the
-                                CIA's Deal With Amazon</em> <br>(The Atlantic, 2014)</cite></a>, it’s easy to imagine
-                    that
+                    investment banks and
+                    <a href="https://www.theatlantic.com/technology/archive/2014/07/the-details-about-the-cias-deal-with-amazon/374632/"
+                        target="_blank" class="footnote-link">the CIA</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Details About the CIA's Deal With Amazon</em>
+                        <br>(The Atlantic, 2014)
+                    </cite>
+                    it’s easy to imagine that
                     the power of your fellow stakeholders would have some effect on the reliability and continued
                     availability of the product.
                 </p>
@@ -679,18 +711,26 @@
                     the internet’s founding dream, its birth ideal, of being a telecommunications network that could
                     survive a nuclear attack, it’s fairly certain any substantive nuclear exchange would render the
                     cloud unusable. Even aside from such nightmare scenarios, the cloud is made possible by a relatively
-                    small number of undersea cables that <a
-                        href="https://www.theverge.com/c/24070570/internet-cables-undersea-deep-repair-ships"
-                        class="footnote-link">require constant maintenance<cite><em>The Cloud Under the
-                                Sea</em> <br>(The Verge, 2024)</cite></a>. Any blue water naval power already has the
-                    firepower and capability to
+                    small number of undersea cables that
+                    <a href="https://www.theverge.com/c/24070570/internet-cables-undersea-deep-repair-ships"
+                        class="footnote-link">require constant maintenance</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Cloud Under the Sea</em>
+                        <br>(The Verge, 2024)
+                    </cite>
+                    Any blue water naval power already has the firepower and capability to
                     severely damage global access to the internet, and thus the cloud. The global geographic
-                    distribution of data centers <a
-                        href="https://www.statista.com/statistics/1228433/data-centers-worldwide-by-country/#:~:text=As%20of%20March%202024%2C%20there,located%20in%20the%20United%20Kingdom."
+                    distribution of data centers
+                    <a href="https://www.statista.com/statistics/1228433/data-centers-worldwide-by-country/#:~:text=As%20of%20March%202024%2C%20there,located%20in%20the%20United%20Kingdom."
                         target="_blank" class="footnote-link">heavily tilts toward the U.S. and
-                        Europe<cite><em>Leading countries by number of data centers 2024</em> <br>(Statista,
-                            2024)</cite></a>. The
-                    cloud is fairly centralized, because the companies that run it are fairly centralized.
+                        Europe</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Leading countries by number of data centers 2024</em>
+                        <br>(Statista, 2024)
+                    </cite>
+                    The cloud is fairly centralized, because the companies that run it are fairly centralized.
                 </p>
                 <p>
                     Cloud storage requires paying someone, an outside entity, for as long as you are engaged in the act
@@ -709,22 +749,32 @@
                     even values. Right now, the dominant cloud storage options are exclusively administered by
                     companies. In November of 2018, at an all-hands meeting in Seattle, an Amazon employee asked CEO and
                     founder Jeff Bezos what he had learned from the recent bankruptcy of Sears. “Amazon is not too big
-                    to fail… <a href="https://www.businessinsider.com/jeff-bezos-says-amazon-will-fail-one-day-2018-11"
+                    to fail…
+                    <a href="https://www.businessinsider.com/jeff-bezos-says-amazon-will-fail-one-day-2018-11"
                         target="_blank" class="footnote-link">In fact, I predict one day Amazon will
-                        fail.<cite><em>Jeff Bezos makes surprise admission about Amazon's life span</em> (Business
-                            Insider, 2018)</cite></a> Amazon
+                        fail.</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Jeff Bezos makes surprise admission about Amazon's life span</em>
+                        (Business Insider, 2018)
+                    </cite>
+                    Amazon
                     will go bankrupt. If you look at large companies, their lifespans tend to be 30-plus years, not a
                     hundred-plus years,” Bezos answered. Bezos was right. Most companies do not last long. They get
                     acquired or split up into pieces or go bankrupt or decline into something much smaller or are
                     upended by catastrophic geopolitical events.
                 </p>
                 <p>
-                    In 2012, Richard Foster, a professor at Yale School of Management, <a
-                        href="https://www.bbc.com/news/business-16611040" target="_blank"
-                        class="footnote-link">found<cite><em>Can a company live forever?</em> (BBC, 2012)</cite></a>
+                    In 2012, Richard Foster, a professor at Yale School of Management,
+                    <a href="https://www.bbc.com/news/business-16611040" target="_blank"
+                        class="footnote-link">found</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Can a company live forever?</em> (BBC, 2012)
+                    </cite>
                     that the
                     average lifespan of
-                    companies listed on the S&P 500 had been decreasing precipitously. It had dropped from 67 years in
+                    companies listed on the S&amp;P 500 had been decreasing precipitously. It had dropped from 67 years in
                     the 1920s to just 15 years. Most companies, even wildly successful behemoths, don’t even last 50
                     years, let alone a hundred.
                 </p>
@@ -744,9 +794,15 @@
                     upstart firms that wish to follow in their ilk, discontinue their services out of necessity,
                     preference, or optimization as they move onto whatever the next shiny thing is that they believe can
                     drive growth. Google has been particularly guilty of this behavior, shutting down its own products
-                    with such regularity that it has become <a href="https://killedbygoogle.com/" target="_blank"
+                    with such regularity that it has become
+                    <a href="https://killedbygoogle.com/" target="_blank"
                         class="footnote-link">a running joke among those of us who are terminally
-                        online.<cite><em>Killed by Google</em></cite></a> During the course of writing this piece Google
+                        online</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Killed by Google</em>
+                    </cite>
+                    During the course of writing this piece Google
                     announced that it
                     was killing its URL Shortener, actively contributing to link rot and abetting the degradation of the
                     world wide web.
@@ -758,14 +814,27 @@
                 <p>
                     Every time I’ve spoken to a gallery guard at an art museum, I’ve found that they hold a deep sense
                     of reverence and responsibility for the collections under their watch. This has been repeatedly
-                    reflected in both <a
-                        href="https://www.newyorker.com/culture/photo-booth/the-secret-lives-of-museum-guards"
+                    reflected in both
+                    <a href="https://www.newyorker.com/culture/photo-booth/the-secret-lives-of-museum-guards"
                         target="_blank" class="footnote-link">journalism covering the people with these
-                        jobs<cite><em>The Secret Lives of Museum Guards</em> (The New Yorker, 2015)</cite></a> and <a
-                        href="https://search.worldcat.org/title/All-the-beauty-in-the-world-:-the-Metropolitan-Museum-of-Art-and-me/oclc/1368050767"
-                        target="_blank" class="footnote-link">their own accounts<cite><em>All the Beauty in the World:
-                                <br>The Metropolitan Museum of Art and Me</em> <br>(Patrick Bringley,
-                            2023)</cite></a>. They stand
+                        jobs</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Secret Lives of Museum Guards</em>
+                        (The New Yorker, 2015)
+                    </cite>
+                    and
+                    <a href="https://search.worldcat.org/title/All-the-beauty-in-the-world-:-the-Metropolitan-Museum-of-Art-and-me/oclc/1368050767"
+                        target="_blank" class="footnote-link">their own accounts</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>
+                            All the Beauty in the World:
+                            <br>The Metropolitan Museum of Art and Me
+                        </em>
+                        <br>(Patrick Bringley, 2023)
+                    </cite>
+                    They stand
                     there, day after day, dealing with entitled tourists, escaped toddlers, food smugglers, hyped-up
                     school groups, and some of the more annoying varieties of possible human behaviors, and they don’t
                     seem to lose a sense of the importance of their work. Even when the institutions they work for don’t
@@ -784,12 +853,14 @@
                 </p>
                 <p>
                     The current web pages and marketing for Microsoft Azure and Google Cloud do not mention cultural or
-                    historical preservation at any point. Only Amazon S3 mentions the concept, presenting <a
-                        href="https://aws.amazon.com/solutions/case-studies/bbc-s3-case-study/" class="footnote-link"
-                        target="_blank">the case study of migrating the BBC’s 100-year-old
-                        archive<cite><em>The BBC Preserves 100 Years of History Using Amazon S3</em> (BBC,
-                            2024)</cite></a> to
-                    its Glacier system between case studies involving Salesforce
+                    historical preservation at any point. Only Amazon S3 mentions the concept, presenting <a href="https://aws.amazon.com/solutions/case-studies/bbc-s3-case-study/" class="footnote-link"
+                        target="_blank">the case study of migrating the BBC’s 100-year-old archive</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The BBC Preserves 100 Years of History Using Amazon S3</em>
+                        (BBC, 2024)
+                    </cite>
+                    to its Glacier system between case studies involving Salesforce
                     data lakes and generative AI.
                 </p>
                 <p>
@@ -822,11 +893,15 @@
                     Another manifestation of the cloud is as a means with which digital products are currently offered,
                     sold, and consumed. Digital copies of books, film, music, games, and journalism, some released under
                     subscription models, some available on digital marketplaces, are all part of our cloud environment.
-                    Over the past decade, the collection development budgets of most libraries <a
-                        href="https://www.libraryjournal.com/story/a-complex-landscape-budgets-and-funding-2024"
+                    Over the past decade, the collection development budgets of most libraries
+                    <a href="https://www.libraryjournal.com/story/a-complex-landscape-budgets-and-funding-2024"
                         class="footnote-link" target="_blank">have moved steadily away from physical
-                        books<cite><em>A Complex Landscape | Budgets and Funding 2024</em> <br>(Library Journal,
-                            2024)</cite></a>
+                        books</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>A Complex Landscape | Budgets and Funding 2024</em>
+                        <br>(Library Journal, 2024)
+                    </cite>
                     and towards cloud-based digital subscriptions.
                 </p>
                 <p>
@@ -838,10 +913,14 @@
                     video game companies fail to preserve their own IP and then ruthlessly pursue litigation when fans
                     attempt pick up the slack, film studios refuse to release entire films and shelve television shows
                     in order to claim write-offs and avoid paying residuals, digital marketplaces disable content that
-                    consumers have already purchased, an entire <a
-                        href="https://rhizome.org/editorial/2020/dec/21/flash-preservation/" target="_blank"
-                        class="footnote-link">generation of web art rendered nonfunctional<cite><em>Emulation or it
-                                Didn’t Happen</em> (Rhizome, 2020)</cite></a>, and
+                    consumers have already purchased, an entire
+                    <a href="https://rhizome.org/editorial/2020/dec/21/flash-preservation/" target="_blank"
+                        class="footnote-link">generation of web art rendered nonfunctional</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Emulation or it Didn’t Happen</em> (Rhizome, 2020)
+                    </cite>
+                    and
                     countless songs, books, shows, games, software, and even entire formats simply vanish without
                     warning, even when contained within the “libraries” of customers who allegedly “own” them.
                 </p>
@@ -878,19 +957,26 @@
                     Minor, played by Vladimir Horowitz and the NBC Symphony Orchestra at Carnegie Hall. On the crimson
                     cover an illustrated pair of disembodied hands play an angled keyboard. It’s worth between $3 and
                     $12 at present. The record is a re-press, as the recording was made in 1943 (of sheet music first
-                    published in 1875 and revised into its final form in 1890). <a
-                        href="https://www.youtube.com/watch?v=jNVV_5sn7Ek" target="_blank"
-                        class="footnote-link">Recordings of the concert also exist on YouTube<cite><em>Vladimir
-                                Horowitz-Toscanini: Tchaikovsky Concerto No. 1, Op. 23 (1943/NBC Symphony
-                                Orchestra)</em> (YouTube, 2024)</cite></a>,
+                    published in 1875 and revised into its final form in 1890).
+                    <a href="https://www.youtube.com/watch?v=jNVV_5sn7Ek" target="_blank"
+                        class="footnote-link">Recordings of the concert also exist on YouTube</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Vladimir Horowitz-Toscanini: Tchaikovsky Concerto No. 1, Op. 23 (1943/NBC Symphony Orchestra)</em>
+                        (YouTube, 2024)
+                    </cite>
                     digitally imported from various analog versions. The record on my shelf is not yet a successful
                     implementation of century-scale storage, depending on your definition, but it’s getting there. If
                     you go on Discogs, the crowdsourced tool for cataloging music releases that also functions as a
-                    global marketplace, you can shop for <a
-                        href="https://www.discogs.com/sell/list?year1=1902&year2=1925&sort=listed,asc&limit=25#/"
+                    global marketplace, you can shop for
+                    <a href="https://www.discogs.com/sell/list?year1=1902&year2=1925&sort=listed,asc&limit=25#/"
                         target="_blank" class="footnote-link">thousands of records that are over a century
-                        old<cite><em>Shop Vinyl Records, CDs, and More released in 1902 to
-                                1925</em> (Discogs)</cite></a>. You need to have a turntable capable of rotating at
+                        old</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Shop Vinyl Records, CDs, and More released in 1902 to 1925</em> (Discogs)
+                    </cite>
+                    You need to have a turntable capable of rotating at
                     78-rpm speed in
                     order to play them, but if you do, you can listen to a recording from over a hundred years ago
                     stored on an analog shellac disc.
@@ -960,11 +1046,15 @@
                     object as the content it is holding. And the ability to play or access the media on them must also
                     be preserved. In 2021, lawyer and FOIA expert Michael Ravnitzky filed a request for copies of video
                     footage of a lecture by legendary computer scientist Admiral Grace Hopper that were present in the
-                    National Security Agency’s archives. <a
-                        href="https://www.muckrock.com/news/archives/2024/jul/10/grace-hopper-lost-lecture-found-nsa/"
-                        target="_blank" class="footnote-link">The NSA denied the request<cite><em>Admiral
-                                Grace Hopper’s landmark lecture is found, but the NSA won’t release it</em> (Muckrock,
-                            2024)</cite></a> in May
+                    National Security Agency’s archives.
+                    <a href="https://www.muckrock.com/news/archives/2024/jul/10/grace-hopper-lost-lecture-found-nsa/"
+                        target="_blank" class="footnote-link">The NSA denied the request</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Admiral Grace Hopper’s landmark lecture is found, but the NSA won’t release it</em>
+                        (Muckrock, 2024)
+                    </cite>
+                    in May
                     of 2024, stating that the agency no longer owned a machine capable of playing back the AMPEX video
                     tapes in their collection.
                 </p>
@@ -998,11 +1088,15 @@
                     consumer products they are already largely obsolete, replaced by a vast streaming infrastructure
                     that intangibly beams content down from the cloud. However, even in a minority capacity, many of
                     them continue to have lives as products. Vinyl records have been fully resurrected now for over a
-                    decade, having even surpassed sales of CDs, the format that supposedly marked their demise. <a
-                        href="https://www.wsj.com/lifestyle/gen-z-loves-cassettes-tapes-ca631750" class="footnote-link"
-                        target="_blank">Gen Z collectors are buying cassette tapes<cite><em>Gen Z Loves Cassettes. But
-                                Wait, How Do These Things Work?</em> (Wall Street Journal, 2024)</cite></a> in
-                    massive quantities. Even when
+                    decade, having even surpassed sales of CDs, the format that supposedly marked their demise.
+                    <a href="https://www.wsj.com/lifestyle/gen-z-loves-cassettes-tapes-ca631750" class="footnote-link"
+                        target="_blank">Gen Z collectors are buying cassette tapes</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Gen Z Loves Cassettes. But Wait, How Do These Things Work?</em>
+                        (Wall Street Journal, 2024)
+                    </cite>
+                    in massive quantities. Even when
                     sold, produced, or maintained as niche offerings, these formats have serious potential that merits
                     serious consideration.
                 </p>
@@ -1020,12 +1114,15 @@
                 </p>
                 <p>
                     Tape drives, which have been used for mainframe computer storage since the 1950s, are remarkably
-                    enduring. Now specifically designed for long term “cold” storage, tape drives have high capacities.
-                    As <a href="https://spectrum.ieee.org/why-the-future-of-data-storage-is-still-magnetic-tape"
-                        target="_blank" class="footnote-link">IBM’s Mark Lantz wrote in 2018<cite><em>Why the Future of
-                                Data Storage is (Still) Magnetic Tape</em> <br>(IEEE
-                            Spectrum, 2018)</cite></a>, “a
-                    single robotic tape library can contain up to 278 petabytes of data. Storing that much data on
+                    enduring. Now specifically designed for long term “cold” storage, tape drives have high capacities. As
+                    <a href="https://spectrum.ieee.org/why-the-future-of-data-storage-is-still-magnetic-tape"
+                        target="_blank" class="footnote-link">IBM’s Mark Lantz wrote in 2018</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Why the Future of Data Storage is (Still) Magnetic Tape</em>
+                        <br>(IEEE Spectrum, 2018)
+                    </cite>
+                    “a single robotic tape library can contain up to 278 petabytes of data. Storing that much data on
                     compact discs would require more than 397 million of them, which if stacked would form a tower more
                     than 476 kilometers high.” Unlike the magnetic tape in cassettes or VHS tapes, the tape itself is
                     much more resilient to physical degradation, and enclosed in cartridges made of heartier materials.
@@ -1050,11 +1147,15 @@
                 <p>
                     Tape also has the advantage of being relatively cheap, far cheaper over the medium term than
                     cloud-based offerings or constantly upgrading your own server or hard drive hardware. In 2021, IBM
-                    priced their own <a href="https://perma.cc/7ZEL-VU8F" class="footnote-link" target="_blank">LTO-9
-                        tape solutions at $5.89 a terabyte<cite><em>IBM ships new LTO 9
-                                Tape Drives with greater density, performance, and resiliency</em> (IBM,
-                            2021)</cite></a>. It’s no accident
-                    that tape drives
+                    priced their own
+                    <a href="https://perma.cc/7ZEL-VU8F" class="footnote-link" target="_blank">LTO-9
+                        tape solutions at $5.89 a terabyte</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>IBM ships new LTO 9 Tape Drives with greater density, performance, and resiliency</em>
+                        (IBM, 2021)
+                    </cite>
+                    It’s no accident that tape drives
                     are the standard for most large-scale cold storage. Most film companies and film libraries, banks,
                     insurance agencies, law firms, and national archives keep a copy of at least some of their data on
                     magnetic tape.
@@ -1244,10 +1345,14 @@
                 </p>
                 <p>
                     The issue with books is their number. There are already a lot of them. The volume of books runs up
-                    against the human capacity to care for them. In 2010, <a
-                        href="https://booksearch.blogspot.com/2010/08/books-of-world-stand-up-and-be-counted.html"
+                    against the human capacity to care for them. In 2010,
+                    <a href="https://booksearch.blogspot.com/2010/08/books-of-world-stand-up-and-be-counted.html"
                         class="footnote-link" target="_blank">Google tried to calculate the total number of books ever
-                        written and published and arrived at 129,864,880<cite><em>Google Book Search</em></cite></a>.
+                        written and published and arrived at 129,864,880</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Google Book Search</em>
+                    </cite>
                     Estimates vary, but
                     each year somewhere between one and four million more are published. As of 2022, the Library of
                     Congress, the most well-funded library on Earth, has only 25 million books. Given the physical space
@@ -1271,31 +1376,41 @@
                 <p>
                     One solution to century scale storage is to scatter your holdings, to put copy after copy all over
                     the world, so that no disaster, war, or sudden loss of funding could ever threaten a digital
-                    collection’s survival. Right now, the internet and computation are not decentralized. As <a
-                        href="https://www.newyorker.com/tech/annals-of-technology/the-mission-to-decentralize-the-internet"
+                    collection’s survival. Right now, the internet and computation are not decentralized. As
+                    <a href="https://www.newyorker.com/tech/annals-of-technology/the-mission-to-decentralize-the-internet"
                         target="_blank" class="footnote-link">Janus
-                        Kopfstein noted in the <em>New Yorker</em><cite><em>The Mission to
-                                Decentralize <br>the Internet</em> <br>(The New Yorker, 2013)</cite></a> in 2013, “a
-                    staggering
-                    percentage of communications flow through a
+                        Kopfstein noted in the <em>New Yorker</em></a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Mission to Decentralize <br>the Internet</em>
+                        <br>(The New Yorker, 2013)
+                    </cite>
+                    in 2013, “a staggering percentage of communications flow through a
                     small set of corporations—and thus, under the profound influence of those companies and other
                     institutions.” This concentration has only accelerated in the intervening decade. Our access to the
                     internet is controlled by telecommunications firms that openly employ anticompetitive practices
-                    without serious recourse, often <a
-                        href="https://ilsr.org/articles/report-most-americans-have-no-real-choice-in-internet-providers/"
-                        target="_blank" class="footnote-link">avoiding each other’s turf<cite><em>Report: Most Americans
-                                Have No Real Choice in Internet
-                                Providers</em> (Institute for Local Self-Reliance, 2020)</cite></a> because
-                    direct competition would limit
+                    without serious recourse, often
+                    <a href="https://ilsr.org/articles/report-most-americans-have-no-real-choice-in-internet-providers/"
+                        target="_blank" class="footnote-link">avoiding each other’s turf</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Report: Most Americans Have No Real Choice in Internet Providers</em>
+                        (Institute for Local Self-Reliance, 2020)
+                    </cite>
+                    because direct competition would limit
                     their rent-seeking and profits. Only a handful of computer operating systems have anything
                     approaching widespread adoption. Chips, graphics cards, and yes, hard drives, are made by a
                     relatively small number of companies, and this is even more true of the parts that comprise them.
                     AMD, Apple, ARM, Broadcom, Marvell, MediaTek, Qualcomm, and Nvidia are all semiconductor customers
-                    of Taiwan Semiconductor Manufacturing Company. This year, <a
-                        href="https://www.reuters.com/world/us/us-official-says-chinese-seizure-tsmc-taiwan-would-be-absolutely-devastating-2024-05-08/"
+                    of Taiwan Semiconductor Manufacturing Company. This year,
+                    <a href="https://www.reuters.com/world/us/us-official-says-chinese-seizure-tsmc-taiwan-would-be-absolutely-devastating-2024-05-08/"
                         target="_blank" class="footnote-link">U.S. Commerce Secretary Gina Raimondo
-                        said<cite><em>US official says Chinese seizure of TSMC in Taiwan would be
-                                'absolutely devastating'</em> (Reuters, 2024)</cite></a>
+                        said</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>US official says Chinese seizure of TSMC in Taiwan would be 'absolutely devastating'</em>
+                        (Reuters, 2024)
+                    </cite>
                     that the United States buys 92% of its chips from TSMC.
 
                 </p>
@@ -1303,21 +1418,30 @@
                     Despite occasional promises, small head nods, and paeans to the contrary, major firms have not been
                     converting their products to open protocols. iMessages are still blue and everyone else is green.
                     Meta products are only interoperable with other Meta products. X, <em>née Twitter</em>, is not interoperable
-                    with anything. Attempts to re-decentralize the internet, like the <a
-                        href="https://web.archive.org/web/20170423053136/https://arkos.io/2017/04/sunset/"
-                        target="_blank" class="footnote-link">self-hosting platform arkOS<cite><em>Sunset</em> (arkOS,
-                            2017)</cite></a>, have
-                    regularly run out of resources and been discontinued.
+                    with anything. Attempts to re-decentralize the internet, like the
+                    <a href="https://web.archive.org/web/20170423053136/https://arkos.io/2017/04/sunset/"
+                        target="_blank" class="footnote-link">self-hosting platform arkOS</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Sunset</em>
+                        (arkOS, 2017)
+                    </cite>
+                    have regularly run out of resources and been discontinued.
                 </p>
                 <p>
                     Still, some attempts at decentralization have been more successful. LOCKSS (Lots of Copies Keep
                     Stuff Safe) is a digital preservation strategy, protocol, and software developed by Victoria Reich
                     and David Rosenthal in 1999 at Stanford Libraries. Rosenthal has spent decades working on and
                     writing about the possibilities and pitfalls in long-term digital storage (this piece
-                    would absolutely not exist without <a href="https://queue.acm.org/detail.cfm?id=1866298"
-                        target="_blank" class="footnote-link">his work<cite><em>Keeping Bits Safe: <br> How Hard Can
-                                It Be?</em> <br>(ACM Queue, 2010)</cite></a>). For LOCKSS, multiple copies of academic
-                    journals are
+                    would absolutely not exist without
+                    <a href="https://queue.acm.org/detail.cfm?id=1866298"
+                        target="_blank" class="footnote-link">his work</a>).
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Keeping Bits Safe: <br> How Hard Can It Be?</em>
+                        <br>(ACM Queue, 2010)
+                    </cite>
+                    For LOCKSS, multiple copies of academic journals are
                     stored across a distributed network; each copy in the system periodically checks itself against
                     other
                     copies for damage and discrepancies, a process of polling and repair. They whisper to each other,
@@ -1328,9 +1452,13 @@
                 </p>
                 <p>
                     What LOCKSS represents is an attempt to put a decentralized and reliable storage system within the
-                    control of a community. The result is a network of 80 research and public libraries <a
-                        href="https://www.lockss.org/gln" class="footnote-link" target="_blank">sharing<cite><em>LOCKSS
-                                Program</em></cite></a> “custody of the scholarly record on library-owned
+                    control of a community. The result is a network of 80 research and public libraries
+                    <a href="https://www.lockss.org/gln" class="footnote-link" target="_blank">sharing</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>LOCKSS Program</em>
+                    </cite>
+                    “custody of the scholarly record on library-owned
                     storage, not in the cloud.” Members of LOCKSS pay a fee based on their budgets, an attempt to spread
                     the financial burden beyond one institution.
                 </p>
@@ -1373,10 +1501,14 @@
                 </p>
                 <p>
                     It’s worth considering the efficacy of piracy and the intentional breaking of intellectual property
-                    law as a long-term preservation tactic. <a href="https://doi.org/10.1080/09528822.2019.1663687"
-                        target="_blank" class="footnote-link"> Abigail De Kosnik, a professor in the Berkeley Center for
-                        New Media, contends<cite><em>Piracy Is the Future of Culture</em> (Abigail De Kosnik,
-                            2019)</cite></a>
+                    law as a long-term preservation tactic.
+                    <a href="https://doi.org/10.1080/09528822.2019.1663687" target="_blank" class="footnote-link">
+                        Abigail De Kosnik, a professor in the Berkeley Center for New Media, contends</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Piracy Is the Future of Culture</em>
+                        (Abigail De Kosnik, 2019)
+                    </cite>
                     that, given the nature of digital cultural output
                     and the failures of the current corporate and institutional orders to properly care for them,
                     piracy-based media preservation efforts are more likely to survive catastrophic future events than
@@ -1433,12 +1565,15 @@
                     allowing for the creation of this piece.
                 </p>
                 <p>
-                    In 2018, digital preservationist and <a
-                        href="https://blog.dshr.org/2018/06/the-four-most-expensive-words-in.html" target="_blank"
-                        class="footnote-link">LOCKSS co-founder David Rosenthal argued<cite><em>
-                                The Four Most Expensive Words in the English Language</em> <br>(David Rosenthal,
-                            2018)</cite></a> that
-                    cryptocurrency-based decentralized storage networks will never catch up to centralized cloud storage
+                    In 2018, digital preservationist and
+                    <a href="https://blog.dshr.org/2018/06/the-four-most-expensive-words-in.html" target="_blank"
+                        class="footnote-link">LOCKSS co-founder David Rosenthal argued</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Four Most Expensive Words in the English Language</em>
+                        <br>(David Rosenthal, 2018)
+                    </cite>
+                    that cryptocurrency-based decentralized storage networks will never catch up to centralized cloud storage
                     offerings on reliability, price, speed, and access terms. The need for encryption of all storage
                     assets for security reasons, the lack of stable pricing, and the constant need for storage market
                     liquidity all create potential long-term issues. Lastly, as Rosenthal also points out, if
@@ -1447,11 +1582,15 @@
                     centralize because it is incentivized to centralize, just like other supposedly decentralized
                     offerings in an unregulated market context. The untested legal status of these systems also poses
                     potential problems. Storing copies of copyrighted intellectual property could lead to problems
-                    within the market itself if providers in certain jurisdictions are <a
-                        href="https://github.com/filecoin-project/specs/issues/65" target="_blank"
-                        class="footnote-link">legally forced to delete data they were contracted to
-                        store<cite><em>Document how removal of data for legal reasons</em> (Github/Filecoin,
-                            2018)</cite></a>. None of these schemes have so far proven that they can function,
+                    within the market itself if providers in certain jurisdictions are
+                    <a href="https://github.com/filecoin-project/specs/issues/65" target="_blank"
+                        class="footnote-link">legally forced to delete data they were contracted to store</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Document how removal of data for legal reasons</em>
+                        (Github/Filecoin, 2018)
+                    </cite>
+                    None of these schemes have so far proven that they can function,
                     let alone thrive, as functional viable marketplaces for a sustained period of time, nor that they
                     can reliably incentivize storage in times of strife or scarcity. Since the development of
                     large-scale trading civilizations, no region on Earth has seen a century pass without a significant
@@ -1484,7 +1623,7 @@
                     store human cultural memory, they should use their resources to attack, subvert, and replace the
                     centralized telecommunications, hardware, and software behemoths that they currently rely upon. A
                     crypto community that is serious about a decentralized internet should be in an all-out war with the
-                    Verizons, AT&Ts, Comcasts, Starlinks, and Spectrums of the world, and treating the dominance of a
+                    Verizons, AT&amp;Ts, Comcasts, Starlinks, and Spectrums of the world, and treating the dominance of a
                     firm like NVIDIA with utter hostility.
                 </p>
                 <p>
@@ -1493,9 +1632,14 @@
                     here: that of centralization versus decentralization in archival practices itself.
                 </p>
                 <p>
-                    Andrew Pettegree and Arthur der Weduwen’s <a href="https://search.worldcat.org/title/1230460593"
-                        target="_blank" class="footnote-link"><em>The Library: A Fragile History</em><cite><em>The
-                                Library: A Fragile History</em> (Andrew Pettegree & Arthur der Weduwen, 2021)</cite></a>
+                    Andrew Pettegree and Arthur der Weduwen’s
+                    <a href="https://search.worldcat.org/title/1230460593"
+                        target="_blank" class="footnote-link"><em>The Library: A Fragile History</em></a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Library: A Fragile History</em>
+                        (Andrew Pettegree &amp; Arthur der Weduwen, 2021)
+                    </cite>
                     opens with the
                     anecdote of a 16th-century Dutch scholar arriving to his appointment at the Holy Roman Emperor’s
                     library to find it in a state of utter neglect and destitution. The printing press had only been
@@ -1541,22 +1685,34 @@
                 <p>
                     I have been avoiding mentioning the most famous destruction of a library in history, that of the
                     fabled Library of Alexandria, not least because the time and circumstances of its destructions
-                    (plural) are not authoritatively determined. But I would offer <a
-                        href="https://time.com/5912689/library-of-alexandria-burning/" target="_blank"
-                        class="footnote-link">the impressions of Richard Ovenden<cite><em>The Story of the
-                                Library of Alexandria Is Mostly a Legend, But the Lesson of Its Burning Is Still Crucial
-                                Today</em> <br>(Time, 2020)</cite></a>, author of <a
-                        href="https://search.worldcat.org/title/Burning-the-books-:-a-history-of-knowledge-under-attack/oclc/1191799080"
-                        target="_blank" class="footnote-link"><em>Burning the Books: A History of the Deliberate
-                        Destruction of Knowledge</em><cite><em>Burning the Books:<br> A
-                                History of the Deliberate
-                                Destruction of Knowledge</em> <br>(John Murray, 2020)</cite></a>, discussing Edward
-                    Gibbon’s account of
-                    the library’s fate in <a
-                        href="https://search.worldcat.org/title/history-of-the-decline-and-fall-of-the-roman-empire/oclc/60367540"
-                        target="_blank" class="footnote-link"><em>The History of the Decline and Fall of the Roman
-                            Empire</em><cite><em>he History of the Decline and Fall of the Roman
-                                Empire</em> (Edward Gibbons, 1776)</cite></a>: “For Gibbon, the Library of Alexandria
+                    (plural) are not authoritatively determined. But I would offer
+                    <a href="https://time.com/5912689/library-of-alexandria-burning/" target="_blank"
+                        class="footnote-link">the impressions of Richard Ovenden</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The Story of the Library of Alexandria Is Mostly a Legend, But the Lesson of Its Burning Is Still Crucial Today</em>
+                        <br>(Time, 2020)
+                    </cite>
+                    author of
+                    <a href="https://search.worldcat.org/title/Burning-the-books-:-a-history-of-knowledge-under-attack/oclc/1191799080"
+                        target="_blank" class="footnote-link"><em>Burning the Books: A History of the Deliberate Destruction of Knowledge</em></a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Burning the Books:
+                            <br> A History of the Deliberate Destruction of Knowledge
+                        </em>
+                        <br>(John Murray, 2020)
+                    </cite>
+                    discussing Edward Gibbon’s account of
+                    the library’s fate in
+                    <a href="https://search.worldcat.org/title/history-of-the-decline-and-fall-of-the-roman-empire/oclc/60367540"
+                        target="_blank" class="footnote-link"><em>The History of the Decline and Fall of the Roman Empire</em></a>:
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>The History of the Decline and Fall of the Roman Empire</em>
+                        (Edward Gibbons, 1776)
+                    </cite>
+                    “For Gibbon, the Library of Alexandria
                     was one of the
                     great achievements of the classical world and its destruction—which he concludes was due to a long
                     and gradual process of neglect and growing ignorance—was a symbol of the barbarity that overwhelmed
@@ -1637,10 +1793,13 @@
                     gathering in forums and Discord channels have done an incredible job preserving literary, music,
                     video game, and film history through aggregation, emulation, and decentralized distribution.
                     High-quality versions of the original unaltered cuts of films like Star Wars (which are no longer
-                    commercially available) are being preserved and held in this way. Volunteer <a
-                        href="https://wiki.archiveteam.org" target="_blank" class="footnote-link">teams of “rogue
-                        archivists”<cite><em>Archive Team</em></cite></a> have
-                    been engaged in decades-long efforts to save digital and web assets in danger of abandonment or
+                    commercially available) are being preserved and held in this way. Volunteer
+                    <a href="https://wiki.archiveteam.org" target="_blank" class="footnote-link">teams of “rogue archivists”</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Archive Team</em>
+                    </cite>
+                    have been engaged in decades-long efforts to save digital and web assets in danger of abandonment or
                     destruction.
                 </p>
                 <p>
@@ -1650,8 +1809,8 @@
                     1999–2020 SETI@home project—<a
                         href="https://www.theatlantic.com/science/archive/2017/05/aliens-on-your-packard-bell/527445/"
                         target="_blank" class="footnote-link">which analyzed collected radio signals in the search for
-                        signs of extraterrestrial intelligence<cite><em>A Brief History of
-                                SETI@Home</em> (The Atlantic, 2017)</cite></a>—points to the ways such a scheme
+                        signs of extraterrestrial intelligence</a><cite><span class="sr-only">Citation: </span><em>A Brief History of
+                        SETI@Home</em> (The Atlantic, 2017)</cite>—points to the ways such a scheme
                     might be possible. Hundreds of thousands of computer users, including then-teenagers like me, gladly
                     turned over their computers to this task. This was not accomplished with a promise of financial
                     compensation, but an appeal to the sheer scope and grandeur of the mission and a genuine invitation
@@ -1686,9 +1845,12 @@
                 <p>
                     This will stay true even with huge potential advancements in storage media on the horizon—<a
                         href="https://www.scientificamerican.com/article/dna-the-ultimate-data-storage-solution/"
-                        target="_blank" class="footnote-link">foremost among them DNA storage<cite><em>DNA: The Ultimate
-                                Data-Storage Solution</em> (Scientific
-                            American, 2021)</cite></a>,
+                        target="_blank" class="footnote-link">foremost among them DNA storage</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>DNA: The Ultimate Data-Storage Solution</em>
+                        (Scientific American, 2021)
+                    </cite>
                     with its incredible capacity for density and replication. The method is currently limited by a
                     painfully slow read/write speed and several processes that have not yet begun to be invented, but
                     once it’s here, that technology will still have to be maintained.
@@ -1697,17 +1859,27 @@
                     Digital storage relies on software. All software and file formats are dependent on upkeep and
                     preservation, as the march of technological advancement renders the hardware and software previously
                     used to read and create media obsolete. Longstanding software is rare enough that it can become an
-                    object of fascination. In 2015, <a
-                        href="https://www.technologyreview.com/2015/08/06/166822/what-is-the-oldest-computer-program-still-in-use"
+                    object of fascination. In 2015,
+                    <a href="https://www.technologyreview.com/2015/08/06/166822/what-is-the-oldest-computer-program-still-in-use"
                         target="_blank" class="footnote-link"><em>MIT Technology Review</em> writer Glenn Fleishman
-                        answered a reader’s question<cite><em>What Is the Oldest Computer
-                                Program Still in Use?</em> (MIT Technology Review, 2015)</cite></a> about what the
-                    oldest computer program still in
+                        answered a reader’s question</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>What Is the Oldest Computer Program Still in Use?</em>
+                        (MIT Technology Review, 2015)
+                    </cite>
+                    about what the oldest computer program still in
                     use was. He concluded that the oldest was a Defense Department contracts management and tracking
-                    system, MOCAS, first created in 1958. It is still in use today, <a
-                        href="https://www.acq.osd.mil/asda/dpc/ce/p2p/docs/training-presentations/2018/P2P-Symposium-Future-of-MOCAS.pdf"
+                    system, MOCAS, first created in 1958. It is still in use today,
+                    <a href="https://www.acq.osd.mil/asda/dpc/ce/p2p/docs/training-presentations/2018/P2P-Symposium-Future-of-MOCAS.pdf"
                         target="_blank" class="footnote-link">despite its scheduled retirement
-                        date<cite><em>Future of MOCAS</em> (2018)</cite></a> of October 1, 2002. Fleishman also
+                        date</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Future of MOCAS</em>
+                        (2018)
+                    </cite>
+                    of October 1, 2002. Fleishman also
                     referenced a 1948 IBM
                     402 punch
                     card system for inventory and accounting that was still being used by a Texas-based water filtration
@@ -1755,16 +1927,19 @@
                     the knowledge and skills required to maintain the entire system."
                 </p>
                 <p>
-                    While plenty of computer scientists and thinkers, like <a
-                        href="https://www.youtube.com/watch?v=GV0A82TCrf0" target="_blank"
-                        class="footnote-link">co-inventor of the internet Vinton Cerf<cite><em>Bit rot (on
-                                digital vellum) | <br>Vint Cerf | TEDxRoma</em> (YouTube, 2014)</cite></a>, have nobly
-                    proposed or
+                    While plenty of computer scientists and thinkers, like
+                    <a href="https://www.youtube.com/watch?v=GV0A82TCrf0" target="_blank"
+                        class="footnote-link">co-inventor of the internet Vinton Cerf</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Bit rot (on digital vellum) | <br>Vint Cerf | TEDxRoma</em>
+                        (YouTube, 2014)
+                    </cite>
+                    have nobly proposed or
                     theorized universal-file-format schemes that might change this reality, they remain a speculative
                     fantasy. The only currently viable way to preserve software is through the hard everyday work of
                     maintenance, adaptation, and emulation. Right now, there is no shortcut or magic format. There is no
                     hack.
-
                 </p>
                 <p>
                     But there are tools, efforts, and protocols that try to ease these burdens. The Web ARChive (WARC)
@@ -1777,12 +1952,15 @@
                     Archeology Lab at the University of Colorado Boulder preserves and documents obsolete media. John
                     Bowers, Jack Cushman, Jayshree Sarathy, and Jonathan Zittrain, here at the Library Innovation Lab,
                     <a href="https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4124742" target="_blank"
-                        class="footnote-link">have proposed “Strong Dark Archives,”<cite><em>‘Time Capsule’ Archiving
-                                Through Strong Dark Archives (SDA):
-                                Designing Trustable Distributed Archives for Sensitive Materials</em> (Harvard Public
-                            Law Working
-                            Paper No. 22-17, 2022)</cite></a> a protocol for
-                    born-digital
+                        class="footnote-link">have proposed “Strong Dark Archives,”</a>
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>‘Time Capsule’ Archiving Through Strong Dark Archives (SDA):
+                             Designing Trustable Distributed Archives for Sensitive Materials
+                        </em>
+                        (Harvard Public Law Working Paper No. 22-17, 2022)
+                    </cite>
+                    a protocol for born-digital
                     sealed records that must be protected for security or legal reasons. There are dozens of other
                     worthy projects and examples. The librarians and archivists of the world have been tackling the
                     challenges of digital preservation for decades—the issue is that no one else is.
@@ -1825,17 +2003,27 @@
                     plan for preservation, these actions should be met with attention and resistance.
                 </p>
                 <p>
-                    We are on the brink of a <a
-                        href="https://www.theatlantic.com/technology/archive/2015/10/raiders-of-the-lost-web/409210/"
-                        target="_blank" class="footnote-link">dark age<cite><em>Raiders of the Lost
-                                Web</em> <br>(The Atlantic, 2015)</cite></a>, or have already entered
+                    We are on the brink of a
+                    <a href="https://www.theatlantic.com/technology/archive/2015/10/raiders-of-the-lost-web/409210/"
+                        target="_blank" class="footnote-link">dark age</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Raiders of the LostWeb</em>
+                        <br>(The Atlantic, 2015)
+                    </cite>
+                    or have already entered
                     one. The scale of art, music, and literature being lost each day as the World Wide Web shifts and
                     degenerates represents the biggest loss of human cultural production since World War II. My
                     generation was continuously warned by teachers, parents, and authority figures that we should be
                     careful online because the internet is written in ink, and yet it turned out to be the exact
-                    opposite. As <a href="https://perma.cc/R237-XDQG" target="_blank" class="footnote-link">writer and
-                        researcher Kevin T. Baker remarked<cite>X (formerly Twitter), 2024</cite></a>, “On the internet,
-                    Alexandria burns daily.”
+                    opposite. As
+                    <a href="https://perma.cc/R237-XDQG" target="_blank" class="footnote-link">writer and
+                        researcher Kevin T. Baker remarked</a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        X (formerly Twitter), 2024
+                    </cite>
+                    “On the internet, Alexandria burns daily.”
                 </p>
                 <figure>
                     <img src="./assets/alexandria.jpg" alt="The Library of Alexandria, 19th-century artistic rendering by German artist O. Von
@@ -1871,14 +2059,18 @@
                     ideologies actively incentivize the mass abandonment of anything that does not have the market value
                     to sustain itself. Nation-states, even social democracies that rank highly on various freedom
                     indices, have a spectacular capacity for both conscious and accidental censorship, selective
-                    preservation, and desertion of the artifacts under their care. As Fernando Báez writes in <a
-                        href="https://search.worldcat.org/title/universal-history-of-the-destruction-of-books-from-ancient-sumer-to-modern-iraq/oclc/819172103"
-                        target="_blank" class="footnote-link"><em>A Universal History of the Destruction of
-                        Books</em><cite><em>A Universal History of the Destruction of
-                            Books: From Ancient
-                                Sumer to Modern Iraq </em> (Fernando Báez and Alfred MacAdam, 2008)</cite></a>, “It’s a
-                    common error to attribute the destruction of books
-                    to
+                    preservation, and desertion of the artifacts under their care. As Fernando Báez writes in
+                    <a href="https://search.worldcat.org/title/universal-history-of-the-destruction-of-books-from-ancient-sumer-to-modern-iraq/oclc/819172103"
+                        target="_blank" class="footnote-link">
+                        <em>A Universal History of the Destruction of Books</em></a>,
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>A Universal History of the Destruction of
+                            Books: From Ancient Sumer to Modern Iraq
+                        </em>
+                        (Fernando Báez and Alfred MacAdam, 2008)
+                    </cite>
+                    “It’s a common error to attribute the destruction of books to
                     ignorant men unaware of their hatred. After twelve years of study, I’ve concluded that the more
                     cultured a nation or a person is, the more willing each is to eliminate books under the pressure of
                     apocalyptic myths.”
@@ -1940,7 +2132,7 @@
                     of a literary magazine was trolling through Princeton University’s rare book archive when he came
                     across an unreleased short story by F. Scott Fitzgerald, which had been intended for publication but
                     never released because of a conflict between the author and his agent. An unpublished Edith Wharton
-                    story was found at Yale’s Beinecke Rare Book & Manuscript Library that same year. In 2010, at that
+                    story was found at Yale’s Beinecke Rare Book &amp; Manuscript Library that same year. In 2010, at that
                     same archive, Richard Wright’s daughter found a previously unpublished novel manuscript hidden
                     within his papers. If you walked into a record store in the early 1950s and asked them for a copy of
                     Vivaldi’s “Four Seasons,” now one of the most ubiquitous pieces of music in the world, chances are
@@ -1954,11 +2146,14 @@
                     between Wolfgang Amadeus Mozart and Antonio Salieri. Just this year, the municipal libraries of
                     Leipzig revealed that another Mozart composition had been rediscovered within their holdings. A few
                     weeks before this piece was published, the <em>New York Times</em> revealed a curator at the Morgan
-                    Library & Museum had unearthed <a
-                        href="https://www.nytimes.com/2024/10/27/arts/music/chopin-waltz-discovery.html" target="_blank"
-                        class="footnote-link"> a previously unknown Chopin Waltz<cite><em>Hear
-                                a Chopin Waltz Unearthed After Nearly 200 Years</em> <br>(The New York Times,
-                            2024)</cite></a>.
+                    Library &amp; Museum had unearthed
+                    <a href="https://www.nytimes.com/2024/10/27/arts/music/chopin-waltz-discovery.html" target="_blank"
+                        class="footnote-link"> a previously unknown Chopin Waltz</a>.
+                    <cite>
+                        <span class="sr-only">Citation: </span>
+                        <em>Hear a Chopin Waltz Unearthed After Nearly 200 Years</em> <br>
+                        (The New York Times, 2024)
+                    </cite>
                 </p>
                 <p>
                     All of these works were republished, rerecorded, or re-performed to great acclaim. What was lost was

--- a/app/century-scale-storage/main.css
+++ b/app/century-scale-storage/main.css
@@ -37,6 +37,18 @@ section>* {
     white-space: nowrap;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
 .section--wide * {
     max-width: 100%;
 }
@@ -171,7 +183,7 @@ p a {
     color: black;
 }
 
-.footnote-link:hover cite {
+.footnote-link:hover + cite, .footnote-link:focus + cite {
     opacity: 1;
     visibility: visible;
 }


### PR DESCRIPTION
See LIL-2986.

This PR exposes the "tooltip" citations to keyboard users and screen-reader users.

- It arranges for their visibility and opacity to toggle on focus, not just on hover

- It extracts the citation out of the anchor tag and adds it as a sibling DOM element, so that reading order is consistent. (VoiceOver was doing something funny, and sometimes reading the citation BEFORE the main link text, sometimes in the MIDDLE OF the main link text, and sometimes afterwards, depending on where the text wrapped, because absolutely positioning inline content DOES affect reading order.)

- It adds a screen-reader only label to the parenthetical citations, so that, when listening to the flow of text, it is clearer why sentences are interrupted.

It's not perfect: in paragraphs with multiple links, VoiceOver is sometimes failing to read the citations of the second, third, etc. links in the normal flow of navigation... and I can't figure out why. It DOES usually get it if you navigate backwards instead... I don't think there's anything I can do about it. At least, I am unaware of a pattern that will work better. I would be surprised if other screen-readers have this problem.

Tooltips will still not be exposed in small viewports or on mobile/touch devices; I believe that can't work with this design (we'd need an alternate display for those sizes and those devices).
