### PR TITLE
Make swup optional for research links.

### DIFF
--- a/app/our-work.html
+++ b/app/our-work.html
@@ -42,7 +42,7 @@ layout: default
 
             <div class="flex flex-col items-start gap-24 body-text">
               {% for project in first_half %}
-                <span><a href="{{ project.url }}" class="interactive-link dark reverse">{{ project.title }}</a></span>
+                <span><a href="{{ project.url }}" class="interactive-link dark reverse" {% if project.no-swup %}data-no-swup="true"{% endif %}>{{ project.title }}</a></span>
               {% endfor %}
             </div>
             <div class="flex flex-col items-start gap-24 body-text">


### PR DESCRIPTION
If a link points to something without LIL's styles (like the Century Scale Storage page), swup fails to make a smooth transition and flashes unstyled content.

This will let us turn off swup for such links.