### PR TITLE
Remove SSE job listing

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -1,7 +1,7 @@
 <lil-header class="block relative z-header">
-  {% if page.slug == "home" %}
+  <!-- {% if page.slug == "home" %}
     {% include hiring-banner.html title="Senior Software Engineer" %}
-  {% endif %}
+  {% endif %} -->
   <header class="pt-24 md:pt-36 nav-container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>

--- a/app/_jobs/senior_software_engineer.md
+++ b/app/_jobs/senior_software_engineer.md
@@ -1,8 +1,0 @@
----
-title: Senior Software Engineer — Full Stack
-category: staff
-order: 1
----
-As a member of our engineering team, the Senior Software Engineer will work across our various tools, applications, and experiments to fulfill LIL’s mission to bring library principles to technological frontiers. The ideal candidate will have experience building performant, testable, maintainable, and fault-tolerant products and tools at scale, for audiences both technical and non-technical.
-
-To apply: <a href="https://sjobs.brassring.com/TGnewUI/Search/Home/Home?partnerid=25240&siteid=5341#jobDetails=2011857_5341" class="interactive-link dark reverse">Application form</a>. In addition to Harvard’s standard application form, please provide a short cover letter explaining how your career trajectory and interests align with our work and mission.


### PR DESCRIPTION
The SSE position has been closed to new applicants; this removes the hiring banner from the homepage and the SSE listing from the Careers page.