### PR TITLE
Update email contact in Public Gov Data blog posts 

### DIFF
--- a/app/_posts/2025-01-30-preserving-public-u-s-federal-data.md
+++ b/app/_posts/2025-01-30-preserving-public-u-s-federal-data.md
@@ -16,4 +16,4 @@ As a first step, we have collected the metadata and primary contents for over 30
 
 In coming weeks we will share full data and metadata for our collection so far. We look forward to seeing how our archive will be used by scholarly researchers and the public. 
 
-To notify us of data you believe should be part of this collection please contact us at [lil@law.harvard.edu](mailto:lil@law.harvard.edu). 
+To notify us of data you believe should be part of this collection please contact us at [publicdata@law.harvard.edu](mailto:publicdata@law.harvard.edu). 

--- a/app/_posts/2025-02-06-announcing-data-gov-archive.md
+++ b/app/_posts/2025-02-06-announcing-data-gov-archive.md
@@ -12,6 +12,6 @@ We’ve built this project on our long-standing commitment to preserving governm
 
 In addition to the data collection, we are releasing [open source software and documentation](https://github.com/harvard-lil/data-vault) for replicating our work and creating similar repositories. With these tools, we aim not only to preserve knowledge ourselves but also to empower others to save and access the data that matters to them.
 
-For suggestions and collaboration on future releases, please contact us at lil@law.harvard.edu.
+For suggestions and collaboration on future releases, please contact us at [publicdata@law.harvard.edu](mailto:publicdata@law.harvard.edu).
 
 This project builds on our work with the [Perma.cc](https://perma.cc) web archiving tool used by courts, law journals, and law firms; the [Caselaw Access Project](https://case.law), sharing all precedential cases of the United States; and our research on [Century Scale Storage](https://lil.law.harvard.edu/century-scale-storage/). This work is made possible with support from the Filecoin Foundation for the Decentralized Web and the Rockefeller Brothers Fund.


### PR DESCRIPTION
We set up a new email for inquiries related to this project. Replacing lil@law.harvard.edu with publicdata@law.harvard.edu in the two blog posts about the project. 