### PR TITLE
Fix display of author names for IIPC 2025 recap blog post

### DIFF
--- a/app/_posts/2025-05-02-iipc-web-archiving-conference-2025-recap.md
+++ b/app/_posts/2025-05-02-iipc-web-archiving-conference-2025-recap.md
@@ -1,6 +1,6 @@
 ---
 title: IIPC Web Archiving Conference 2025 Recap
-author: kristi-mukk, clare-stanton
+author: [kristi-mukk, clare-stanton]
 ---
 The Perma team has landed back in the US after our trip to the [International Internet Preservation Consortium](https://netpreserve.org/)’s Web Archiving Conference. This year the IIPC met in Oslo at the National Library of Norway, and the conference's theme was “Towards Best Practices.” 
 


### PR DESCRIPTION
I noticed that the author names in the [IIPC 2025 recap are](https://lil.law.harvard.edu/blog/2025/05/02/iipc-web-archiving-conference-2025-recap/) aren't displaying properly. Seems like our parsing logic is fussy about how the names are structured.

Before:
![iipc_before](https://github.com/user-attachments/assets/19528be4-5d65-45b1-bb9c-4c95090d0464)

After:
![iipc_after](https://github.com/user-attachments/assets/567a6f4a-d6bc-4079-990b-042a12bb3cb4)
