### PR TITLE
Fix localhost link on WACZ Exhibitor page

### DIFF
--- a/app/_our_work/wacz-exhibitor.md
+++ b/app/_our_work/wacz-exhibitor.md
@@ -21,4 +21,4 @@ This implementation:
 
 [wacz-exhibitor on GitHub](https://github.com/harvard-lil/wacz-exhibitor)
 
-See also: [Live Demo](https://warcembed-demo.lil.tools/), [Blog post](http://localhost:8080/blog/2022/09/15/opportunities-and-challenges-of-client-side-playback/)
+See also: [Live Demo](https://warcembed-demo.lil.tools/), [Blog post](/blog/2022/09/15/opportunities-and-challenges-of-client-side-playback/)


### PR DESCRIPTION
Before:

* Blog post link on the [WACZ Exhibitor](https://lil.law.harvard.edu/our-work/wacz-exhibitor/) page sent you to localhost

After:

* Blog post link now sends you to the correct URL