### PR TITLE
Add CloudCannon CMS Configuration

### DIFF
--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -4,17 +4,23 @@ paths:
   uploads: uploads
   static: ''
 collections_config:
-  pages:
-    path: ''
-    name: Pages
-    icon: wysiwyg
-    disable_add: false
-    disable_add_folder: false
-    disable_file_actions: false
-  drafts:
+  Data (People, Additional Research, Etc.):
+    path: _data
+    name: Data
+    icon: list
+    disable_url: true
+    description: ''
+    _enabled_editors:
+    disable_add: true
+    disable_add_folder: true
+    disable_file_actions: true
+  Draft Blog Posts:
     path: _drafts
     name: Drafts
-    icon: event
+    icon: psychology_alt
+    disable_url: false
+    description: ''
+    _enabled_editors:
     _inputs:
       categories:
         type: multiselect
@@ -36,24 +42,13 @@ collections_config:
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
-  events:
-    path: _events
-    name: Events
-    icon: event
-    disable_add: false
-    disable_add_folder: false
-    disable_file_actions: false
-  our_work:
-    path: _our_work
-    name: Our Work
-    icon: group_work
-    disable_add: false
-    disable_add_folder: false
-    disable_file_actions: false
-  posts:
+  Blog Posts:
     path: _posts
     name: Posts
-    icon: event_available
+    icon: newspaper
+    disable_url: false
+    description: ''
+    _enabled_editors:
     _inputs:
       categories:
         type: multiselect
@@ -79,24 +74,51 @@ collections_config:
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
-  data:
-    path: _data
-    name: Data
-    icon: data_usage
-    disable_add: true
-    disable_add_folder: true
-    disable_file_actions: true
-  jobs:
-    path: _jobs
-    name: Jobs
-    icon: sos
+  Events:
+    path: _events
+    name: Events
+    icon: event
+    disable_url: false
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
-  our_work_pageless:
+  Jobs:
+    path: _jobs
+    name: Jobs
+    icon: person_search
+    disable_url: true
+    description: ''
+    _enabled_editors:
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  Our Work (listed, but no project page):
     path: _our_work_pageless
     name: Our Work Pageless
-    icon: workspaces
+    icon: work_off
+    disable_url: true
+    description: ''
+    _enabled_editors:
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  Our Work:
+    path: _our_work
+    name: Our Work
+    icon: work_outline
+    disable_url: false
+    description: ''
+    _enabled_editors:
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  Other Pages:
+    path: ''
+    name: Other Pages (Home, About, 404, etc.)
+    icon: toc
+    disable_url: false
+    description: ''
+    _enabled_editors:
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -1,0 +1,130 @@
+_schema: _schema
+source: /app/
+paths:
+  uploads: uploads
+  static: ''
+collections_config:
+  pages:
+    path: ''
+    name: Pages
+    icon: wysiwyg
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  drafts:
+    path: _drafts
+    name: Drafts
+    icon: event
+    _inputs:
+      categories:
+        type: multiselect
+        options:
+          allow_create: true
+          empty_type: array
+          values: collections.posts[*].categories
+        cascade: true
+      tags:
+        type: multiselect
+        options:
+          allow_create: true
+          empty_type: array
+          values: collections.posts[*].tags
+        cascade: true
+    create:
+      path: ''
+      publish_to: posts
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  events:
+    path: _events
+    name: Events
+    icon: event
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  our_work:
+    path: _our_work
+    name: Our Work
+    icon: group_work
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  posts:
+    path: _posts
+    name: Posts
+    icon: event_available
+    _inputs:
+      categories:
+        type: multiselect
+        options:
+          allow_create: true
+          empty_type: array
+          values: collections.posts[*].categories
+        cascade: true
+      tags:
+        type: multiselect
+        options:
+          allow_create: true
+          empty_type: array
+          values: collections.posts[*].tags
+        cascade: true
+    add_options:
+      - name: Add Post
+      - name: Add Draft
+        collection: drafts
+    create:
+      path: >-
+        [relative_base_path]/{date|year}-{date|month}-{date|day}-{title|slugify}.[ext]
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  data:
+    path: _data
+    name: Data
+    icon: data_usage
+    disable_add: true
+    disable_add_folder: true
+    disable_file_actions: true
+  jobs:
+    path: _jobs
+    name: Jobs
+    icon: sos
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+  our_work_pageless:
+    path: _our_work_pageless
+    name: Our Work Pageless
+    icon: workspaces
+    disable_add: false
+    disable_add_folder: false
+    disable_file_actions: false
+_snippets_imports:
+  jekyll: true
+timezone: America/New_York
+markdown:
+  engine: kramdown
+  options:
+    xhtml: false
+    breaks: false
+    linkify: false
+    typographer: false
+    spaced_lists: false
+    sentence_per_line: false
+    gfm: false
+    code_block_fences: '```'
+    escape_snippets_in_code_blocks: false
+    treat_indentation_as_code: true
+    table: false
+    strikethrough: false
+    subscript: false
+    superscript: false
+    heading_ids: false
+    attributes: true
+    attribute_elements:
+      inline: right
+      block: below
+      tr: none
+      td: none
+      li: right-of-prefix

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -3,15 +3,6 @@ source: /app/
 paths:
   uploads: uploads
   static: ''
-
-_defaults:
-  posts:
-    layout: post
-    author: rebecca-cremona
-    title: ""
-    categories: []
-    tags: []
-
 collections_config:
   Data (People, Additional Research, Etc.):
     path: _data
@@ -31,30 +22,6 @@ collections_config:
     description: ''
     _enabled_editors:
     _inputs:
-      title:
-        type: text
-        label: Post Title
-      author:
-        type: select
-        label: Author
-        options:
-          values:
-            - value: rebecca-cremona
-              label: "Rebecca Cremona - Senior Software Engineer"
-            - value: jack-cushman
-              label: "Jack Cushman - Director"
-            - value: harmony-eidolon
-              label: "Harmony Eidolon - Program Coordinator"
-            - value: kristi-mukk
-              label: "Kristi Mukk - User Support Coordinator"
-            - value: jacob-rhoades
-              label: "Jacob Rhoades - Senior Product Designer"
-      layout:
-        type: select
-        options:
-          values:
-            - post
-        hidden: true
       categories:
         type: multiselect
         options:
@@ -72,12 +39,6 @@ collections_config:
     create:
       path: ''
       publish_to: posts
-      extra_data:
-        layout: post
-        author: rebecca-cremona
-        title: ""
-        categories: []
-        tags: []
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
@@ -89,30 +50,6 @@ collections_config:
     description: ''
     _enabled_editors:
     _inputs:
-      title:
-        type: text
-        label: Post Title
-      author:
-        type: select
-        label: Author
-        options:
-          values:
-            - value: rebecca-cremona
-              label: "Rebecca Cremona - Senior Software Engineer"
-            - value: jack-cushman
-              label: "Jack Cushman - Director"
-            - value: harmony-eidolon
-              label: "Harmony Eidolon - Program Coordinator"
-            - value: kristi-mukk
-              label: "Kristi Mukk - User Support Coordinator"
-            - value: jacob-rhoades
-              label: "Jacob Rhoades - Senior Product Designer"
-      layout:
-        type: select
-        options:
-          values:
-            - post
-        hidden: true
       categories:
         type: multiselect
         options:
@@ -134,12 +71,6 @@ collections_config:
     create:
       path: >-
         [relative_base_path]/{date|year}-{date|month}-{date|day}-{title|slugify}.[ext]
-      extra_data:
-        layout: post
-        author: rebecca-cremona
-        title: ""
-        categories: []
-        tags: []
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
@@ -191,7 +122,6 @@ collections_config:
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
-
 _snippets_imports:
   jekyll: true
 timezone: America/New_York

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -50,8 +50,37 @@ collections_config:
     description: ''
     _enabled_editors:
     _inputs:
+      title:
+        type: text
+        label: Post Title
+        comment: The main title of your blog post
+      author:
+        type: select
+        label: Author
+        comment: Select the post author from team members
+        options:
+          values: data.people
+          value_key: key
+          preview:
+            text: 
+              - key: name  # This displays the full name in the dropdown
+      layout:
+        type: select
+        label: Layout
+        comment: Choose the layout template for this post
+        options:
+          values:
+            - post
+            - default
+        hidden: true  # Hide this since "post" is the standard for blog posts
+      date:
+        type: datetime
+        label: Publish Date
+        timezone: America/New_York
       categories:
         type: multiselect
+        label: Categories
+        comment: Add categories to organize your posts
         options:
           allow_create: true
           empty_type: array
@@ -59,11 +88,17 @@ collections_config:
         cascade: true
       tags:
         type: multiselect
+        label: Tags
+        comment: Add tags for better discoverability
         options:
           allow_create: true
           empty_type: array
           values: collections.posts[*].tags
         cascade: true
+      guest-author:
+        type: text
+        label: Guest Author
+        comment: For posts by non-team members (optional)
     add_options:
       - name: Add Post
       - name: Add Draft

--- a/cloudcannon.config.yml
+++ b/cloudcannon.config.yml
@@ -3,6 +3,15 @@ source: /app/
 paths:
   uploads: uploads
   static: ''
+
+_defaults:
+  posts:
+    layout: post
+    author: rebecca-cremona
+    title: ""
+    categories: []
+    tags: []
+
 collections_config:
   Data (People, Additional Research, Etc.):
     path: _data
@@ -22,6 +31,30 @@ collections_config:
     description: ''
     _enabled_editors:
     _inputs:
+      title:
+        type: text
+        label: Post Title
+      author:
+        type: select
+        label: Author
+        options:
+          values:
+            - value: rebecca-cremona
+              label: "Rebecca Cremona - Senior Software Engineer"
+            - value: jack-cushman
+              label: "Jack Cushman - Director"
+            - value: harmony-eidolon
+              label: "Harmony Eidolon - Program Coordinator"
+            - value: kristi-mukk
+              label: "Kristi Mukk - User Support Coordinator"
+            - value: jacob-rhoades
+              label: "Jacob Rhoades - Senior Product Designer"
+      layout:
+        type: select
+        options:
+          values:
+            - post
+        hidden: true
       categories:
         type: multiselect
         options:
@@ -39,6 +72,12 @@ collections_config:
     create:
       path: ''
       publish_to: posts
+      extra_data:
+        layout: post
+        author: rebecca-cremona
+        title: ""
+        categories: []
+        tags: []
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
@@ -53,34 +92,29 @@ collections_config:
       title:
         type: text
         label: Post Title
-        comment: The main title of your blog post
       author:
         type: select
         label: Author
-        comment: Select the post author from team members
         options:
-          values: data.people
-          value_key: key
-          preview:
-            text: 
-              - key: name  # This displays the full name in the dropdown
+          values:
+            - value: rebecca-cremona
+              label: "Rebecca Cremona - Senior Software Engineer"
+            - value: jack-cushman
+              label: "Jack Cushman - Director"
+            - value: harmony-eidolon
+              label: "Harmony Eidolon - Program Coordinator"
+            - value: kristi-mukk
+              label: "Kristi Mukk - User Support Coordinator"
+            - value: jacob-rhoades
+              label: "Jacob Rhoades - Senior Product Designer"
       layout:
         type: select
-        label: Layout
-        comment: Choose the layout template for this post
         options:
           values:
             - post
-            - default
-        hidden: true  # Hide this since "post" is the standard for blog posts
-      date:
-        type: datetime
-        label: Publish Date
-        timezone: America/New_York
+        hidden: true
       categories:
         type: multiselect
-        label: Categories
-        comment: Add categories to organize your posts
         options:
           allow_create: true
           empty_type: array
@@ -88,17 +122,11 @@ collections_config:
         cascade: true
       tags:
         type: multiselect
-        label: Tags
-        comment: Add tags for better discoverability
         options:
           allow_create: true
           empty_type: array
           values: collections.posts[*].tags
         cascade: true
-      guest-author:
-        type: text
-        label: Guest Author
-        comment: For posts by non-team members (optional)
     add_options:
       - name: Add Post
       - name: Add Draft
@@ -106,6 +134,12 @@ collections_config:
     create:
       path: >-
         [relative_base_path]/{date|year}-{date|month}-{date|day}-{title|slugify}.[ext]
+      extra_data:
+        layout: post
+        author: rebecca-cremona
+        title: ""
+        categories: []
+        tags: []
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
@@ -157,6 +191,7 @@ collections_config:
     disable_add: false
     disable_add_folder: false
     disable_file_actions: false
+
 _snippets_imports:
   jekyll: true
 timezone: America/New_York


### PR DESCRIPTION
## Add CloudCannon CMS Configuration

This PR adds the initial CloudCannon configuration to enable content management for our Jekyll site.

### What's Added
- `cloudcannon.config.yml` - Basic CMS configuration with collections for:
  - Blog Posts (`_posts`)
  - Draft Blog Posts (`_drafts`) 
  - Events (`_events`)
  - Jobs (`_jobs`)
  - Our Work (`_our_work`)
  - Data files (`_data`)

### What This Enables
- Content editors can now create and edit blog posts through CloudCannon's web interface
- Simplified workflow for team members to publish blog content

### Next Steps
- Fine-tune form inputs for blog post metadata (author dropdowns, etc.)
- Configure publishing workflows
