### PR TITLE
Make text in site's HTML editable via CloudCannon's "visual editor"

### DIFF
--- a/app/404.html
+++ b/app/404.html
@@ -6,11 +6,11 @@ permalink: /404.html
 
 <section class="container pb-150">
   <div class="page-hero simple relative z-[1]">
-    <h1 class="page-hero__title">Oops!</h1>
-    <h2 class="page-hero__subtitle flex flex-col gap-24 !max-w-[1080px]">
+    <h1 class="page-hero__title editable">Oops!</h1>
+    <h2 class="page-hero__subtitle flex flex-col gap-24 !max-w-[1080px] editable">
       We can’t seem to find the page you are looking for.
     </h2>
-    <p>
+    <p class="editable">
       To report a broken link, please <a class="interactive-link dark reverse" href="mailto:{{ site.email }}">contact us.</a>
     </p>
   </div>

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -2,6 +2,7 @@
 title: About Us
 slug: about
 description: Our mission is to grow knowledge and community by bringing library principles to technological frontiers.
+jobs-link-label: View Open Positions
 layout: default
 ---
 
@@ -16,8 +17,8 @@ layout: default
 
   <section class="container md:mb-12">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-24 md:gap-40 items-baseline">
-      <h2 class="h2">Who We Are</h2>
-      <div class="md:col-span-2 body-text flex flex-col gap-24 max-w-[700px]">
+      <h2 class="h2 editable">Who We Are</h2>
+      <div class="md:col-span-2 body-text flex flex-col gap-24 max-w-[700px] editable">
         <p>We are a team of librarians, technologists, lawyers, designers, and more, and we work out of the Harvard Law School Library.</p>
         <p>We believe that libraries play a fundamental role in humanity as open, privacy-respecting, and sustainable information spaces. We also believe technology holds great power to break down barriers to information creation, preservation, and use.</p>
       </div>
@@ -32,17 +33,17 @@ layout: default
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
       <figcaption class="block container text-16 py-8">
-        <strong>Credit: Bob O’Connor</strong>
+        <strong class="editable">Credit: Bob O’Connor</strong>
       </figcaption>
     </figure>
   </section>
 
   <section class="bg-green py-48 md:py-72 w-full">
     <div class="container flex flex-col md:grid md:grid-cols-2 gap-32 md:gap-100 md:items-center">
-      <h2 class="h2">Library principles can manifest in any technology and provide a roadmap to mindful building.</h2>
+      <h2 class="h2 editable">Library principles can manifest in any technology and provide a roadmap to mindful building.</h2>
       <div class="flex flex-col gap-20 md:gap-30 body-text">
-        <h3 class="label">We strive to cultivate</h3>
-        <div class="flex flex-col gap-16 md:gap-24 max-w-[520px]">
+        <h3 class="label editable">We strive to cultivate</h3>
+        <div class="flex flex-col gap-16 md:gap-24 max-w-[520px] editable">
           <p>Collection, curation, and preservation of knowledge and its provenance</p>
           <p>Equal and private access to knowledge</p>
           <p>Community service, building, and empowerment through knowledge</p>
@@ -52,7 +53,7 @@ layout: default
   </section>
 
   <section class="container ">
-    <h2 class="h2 mt-12 mb-48 md:mb-72">People at the Lab</h2>
+    <h2 class="h2 mt-12 mb-48 md:mb-72 editable">People at the Lab</h2>
     <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120 pb-48 md:pb-72">
       {% assign affiliates = site.data.people | where: "affiliated", true | sort: "sort_name" %}
       {% assign sections = "Faculty Director, Staff" | split: ", " %}
@@ -70,7 +71,7 @@ layout: default
       {% endfor %}
     </div>
     <div class="pt-48 md:pt-72 border-t-1 border-black">
-      <h2 class="h2">Affiliates</h2>
+      <h2 class="h2 editable">Affiliates</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-32 md:gap-x-60 lg:gap-x-90 xl:gap-x-120">
         {% assign affiliates = site.data.people | where: "affiliated", true | sort: "sort_name" %}
         {% assign sections = "Affiliates" | split: ", " %}
@@ -92,14 +93,14 @@ layout: default
         {% include header-splash-logo.html %}
       </div>
       <div>
-        {% include arrow-link.html label="View Open Positions" href="/jobs/" %}
+        {% include arrow-link.html label=page.jobs-link-label href="/jobs/" %}
       </div>
       <div class="w-40">
       </div>
     </div>
     <section class="bg-gray pt-48 pb-6 tbl:pt-60 tbl:pb-24 w-full">
       <div class="container">
-        <h2 class="h2 tbl:mt-12 tbl:mb-24">Past Affiliates</h2>
+        <h2 class="h2 tbl:mt-12 tbl:mb-24 editable">Past Affiliates</h2>
         <div class="flex flex-col items-start w-full">
           {% assign old_friends = affiliates | where: "current", nil %}
           {% for person in old_friends %}
@@ -111,8 +112,8 @@ layout: default
   </section>
 
   <section class="container">
-    <h2 class="h2 mt-12 md:mt-0 mb-48 tbl:mb-36 md:mb-60">Supported By</h2>
-    <p class="body-text mb-48">We gratefully acknowledge support from, and collaboration with, these organizations.</p>
+    <h2 class="h2 mt-12 md:mt-0 mb-48 tbl:mb-36 md:mb-60 editable">Supported By</h2>
+    <p class="body-text mb-48 editable">We gratefully acknowledge support from, and collaboration with, these organizations.</p>
     
     {% include about-sponsor-group.html supporters=site.data.supporters.institutions %}
     <hr class="w-[200px] mx-auto my-12 border-t-4 border-gray-300">

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -12,7 +12,7 @@ custom-css: ['blog-search']
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}
     <div class="flex flex-col gap-32 pb-40 border-b-1 border-black">
-      <h1 class="page-hero__title editable">Blog</h1>
+      <h1 class="page-hero__title">{{ page.title }}</h1>
       {% include blog-search.html %}
     </div>
   </div>

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -12,7 +12,7 @@ custom-css: ['blog-search']
   <div class="container flex flex-col gap-50 mb-56">
     {% include tag-filter.html %}
     <div class="flex flex-col gap-32 pb-40 border-b-1 border-black">
-      <h1 class="page-hero__title">Blog</h1>
+      <h1 class="page-hero__title editable">Blog</h1>
       {% include blog-search.html %}
     </div>
   </div>

--- a/app/contact/index.html
+++ b/app/contact/index.html
@@ -2,6 +2,7 @@
 title: Contact
 slug: contact
 description: Sign up for our newsletter or shoot us an email if you’re interested in any of our projects. All of our code is open source. Send a pull request on GitHub if you want to collaborate.
+contact-heading: Get In Touch
 layout: default
 ---
 
@@ -12,4 +13,4 @@ layout: default
   </div>
 </section>
 
-{% include contact-section.html heading="Get In Touch" %}
+{% include contact-section.html heading=page.contact-heading %}

--- a/app/index.html
+++ b/app/index.html
@@ -12,13 +12,13 @@ sharing-card-type: summary_large_image
 </div>
 
 <div class="bg-black text-white w-full py-48 md:pt-72 md:pb-120 continer text-center flex flex-col justify-center items-center gap-20 md:gap-32">
-  <div class="font-mono uppercase tracking-8 text-green text-16 md:text-24 font-normal">Our Mission</div>
-  <div contenteditable class="text-28 md:text-54 leading-120 max-w-[1200px] mx-12">To grow knowledge and community by bringing <strong>library principles</strong> to <strong>technological frontiers.</strong></div>
+  <div class="font-mono uppercase tracking-8 text-green text-16 md:text-24 font-normal editable">Our Mission</div>
+  <div contenteditable class="text-28 md:text-54 leading-120 max-w-[1200px] mx-12 editable">To grow knowledge and community by bringing <strong>library principles</strong> to <strong>technological frontiers.</strong></div>
 </div>
 
 <div class="bg-blue py-32">
   <div class="container flex flex-col sm:flex-row sm:items-center sm:justify-between gap-12 md:gap-24">
-    <h2 class="text-14 md:text-18 tracking-8 uppercase font-medium">Follow our latest projects</h2>
+    <h2 class="text-14 md:text-18 tracking-8 uppercase font-medium editable">Follow our latest projects</h2>
     <ul class="flex items-center gap-60 text-[24px] leading-[120%]">
       <li>
         {% include arrow-link.html label="Blog" href="/blog/" reverse=true %}
@@ -32,9 +32,9 @@ sharing-card-type: summary_large_image
 
 <div class="container flex flex-col gap-50 md:gap-100">
   <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 mt-36 sm:mt-48 items-baseline">
-    <h2 class="h2">Who We Are</h2>
+    <h2 class="h2 editable">Who We Are</h2>
     <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50 z-10">
-      <div class="flex flex-col gap-20">
+      <div class="flex flex-col gap-20 editable">
         <p>Our team combines librarians, technologists, lawyers, and more to build tools and conduct research that empowers access to our shared knowledge and cultural heritage.</p>
       </div>
       {% include arrow-link.html label="Learn More About Who We Are" href="/about/" reverse=true %}
@@ -69,9 +69,9 @@ sharing-card-type: summary_large_image
 
   <div class="container flex flex-col gap-50 md:gap-100">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-50 pb-50 md:pb-72 border-b-1 border-black items-baseline">
-      <h2 class="h2">Our Work</h2>
+      <h2 class="h2 editable">Our Work</h2>
       <div class="md:col-span-2 body-text flex flex-col gap-28 md:gap-50">
-        <div class="flex flex-col gap-20">
+        <div class="flex flex-col gap-20 editable">
           <p>Platforms like Perma.cc translate the traditional roles of libraries into the digital age. Explorations like WARC-GPT empower practitioners to learn and leverage new technologies in the context of their field.</p>
         </div>
         {% include arrow-link.html label="View All Projects" href="/our-work/" reverse=true %}

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -7,7 +7,7 @@ layout: default
 <section class="container">
   <div class="page-hero simple">
     <h1 class="page-hero__title">{{ page.title }}</h1>
-    <div class="page-hero__subtitle">
+    <div class="page-hero__subtitle editable">
       Joining our team means standing at the intersection of law, librarianship, and technology within an academic context. We offer a low-pressure, self-directed environment with lots of room to explore, learn, collaborate, and teach.
     </div>
   </div>
@@ -22,13 +22,13 @@ layout: default
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
       <figcaption class="block container text-16 py-8">
-        <strong>Credit: Bob O’Connor</strong>
+        <strong class="editable">Credit: Bob O’Connor</strong>
       </figcaption>
     </figure>
   </section>
 
   <section class="container flex flex-col gap-24 md:gap-40{% if site.jobs.size == 0 %} pb-66{% endif %}">
-    <h2 class="h2">Background</h2>
+    <h2 class="h2 editable">Background</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
       {% assign background_sections = site.jobs | where:"category","background" | sort: "order" %}
@@ -42,7 +42,7 @@ layout: default
   {% assign staff_sections = site.jobs | where:"category","staff" | sort: "order" %}
   {% if staff_sections.size > 0 %}
   <section class="container flex flex-col gap-24 md:gap-40{% if staff_sections.size == site.jobs.size %} pb-66{% endif %}">
-    <h2 class="h2">Staff Positions</h2>
+    <h2 class="h2 editable">Staff Positions</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         {% for section in staff_sections %}
@@ -56,7 +56,7 @@ layout: default
   {% assign research_sections = site.jobs | where:"category","research" | sort: "order" %}
   {% if research_sections.size > 0 %}
   <section class="container flex flex-col gap-24 md:gap-40 pb-66">
-    <h2 class="h2">Research Positions</h2>
+    <h2 class="h2 edtiable">Research Positions</h2>
     <div class="md:grid md:grid-cols-12">
       <div class="w-full md:col-span-9 md:col-start-4">
         {% for section in research_sections %}

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -15,9 +15,9 @@ layout: default
   </section>
 
   <section class="container flex flex-col gap-24 md:gap-36 pb-72 md:pb-96">
-    <h2 class="h2">Research</h2>
+    <h2 class="h2 editable">Research</h2>
     <div class="md:col-span-2 body-text flex flex-col gap-50">
-      <p class="flex flex-col gap-20 max-w-[700px]">
+      <p class="flex flex-col gap-20 max-w-[700px] editable">
         Recent and ongoing explorations in areas relating to access to knowledge, memory, and legal practice.
       </p>
     </div>
@@ -63,9 +63,9 @@ layout: default
 
   <section class="container pb-36">
     <div class="flex flex-col md:grid md:grid-cols-3 gap-28 md:gap-40 items-baseline">
-      <h2 class="h2">Platforms</h2>
+      <h2 class="h2 editable">Platforms</h2>
       <div class="md:col-span-2 body-text flex flex-col gap-50">
-        <p class="flex flex-col gap-20 max-w-[700px]">
+        <p class="flex flex-col gap-20 max-w-[700px] editable">
           Tools are the heart of the Library Innovation Lab. We build things. Our platforms each have their own user base and long-term goals.
         </p>
       </div>


### PR DESCRIPTION
A small amount of text around the website is written directly in the HTML, rather than supplied via data files, headmatter, config, or markdown.

This PR makes that text directly editable via Cloudcannon's editor.

Editable elements will be outlined in yellow, in that view. Editing an inline element should pull up an appropriate WYSIWYG editor, with only inline options allowed. Block elements should pull up a more complex editor. We can more fully configure both, as we go.

I intentionally included the 404 page's link, even though it include an anchor with tags, which certainly will be disappeared if edited in the non-code view:
![image](https://github.com/user-attachments/assets/d48608bf-a729-4910-814b-84d6b79b1848)

I did so because I want to experiment with adding a custom "snippet" (https://cloudcannon.com/documentation/articles/what-is-a-snippet/), or custom style, that might make including those possible/easy.