### PR TITLE
add browser cache busting to new deploy

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -58,6 +58,20 @@ jobs:
         with:
           name: site-build
           path: build/
+     
+      - name: Generate cache-busting strings
+        run: |
+          echo "CSS_BUST=$(date +%s)" >> $GITHUB_ENV
+          echo "JS_BUST=$(date +%s)" >> $GITHUB_ENV
+
+      - name: Replace cache-busting placeholders
+        run: |
+          find build -name '*.html' -exec sed -i "s/CSS_BUST/${{ env.CSS_BUST }}/g" {} +
+          find build -name '*.html' -exec sed -i "s/JS_BUST/${{ env.JS_BUST }}/g" {} +
+      
+      - name: Confirm cache-busting strings applied
+        run: |
+          grep -q 'v=' build/index.html && echo "Cache busting applied ✅" || (echo "❌ Cache busting missing" && exit 1)
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -49,7 +49,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test-build
-    # if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -49,7 +49,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test-build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     steps:
       - uses: actions/checkout@v4
       

--- a/app/_includes/custom-css.html
+++ b/app/_includes/custom-css.html
@@ -1,10 +1,1 @@
-{% if layout.custom-css %}
-  {% for file in layout.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?css-cache-buster=52">
-  {% endfor %}
-{% endif %}
-{% if page.custom-css %}
-  {% for file in page.custom-css %}
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?css-cache-buster=52">
-  {% endfor %}
-{% endif %}
+<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?v=CSS_BUST">

--- a/app/_includes/custom-css.html
+++ b/app/_includes/custom-css.html
@@ -1,1 +1,10 @@
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?v=CSS_BUST">
+{% if layout.custom-css %}
+  {% for file in layout.custom-css %}
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?v=CSS_BUST">
+  {% endfor %}
+{% endif %}
+{% if page.custom-css %}
+  {% for file in page.custom-css %}
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/{{ file | strip }}.css?v=CSS_BUST">
+  {% endfor %}
+{% endif %}

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -12,11 +12,11 @@
     <link rel="icon" href="{{ site.baseurl }}/assets/images/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/images/apple-touch-favicon.png">
     <link rel="manifest" href="{{ site.baseurl }}/manifest.webmanifest">
-    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?css-cache-buster=52">
+    <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=CSS_BUST">
     <link rel="alternate" href="{{ site.baseurl }}/blog/feed/" type="application/rss+xml" title="RSS Feed">
-    <script src="{{ site.baseurl }}/assets/lib/gsap@3.12.5/gsap.min.js"></script>
-    <script src="{{ site.baseurl }}/assets/lib/swup@4.7.0/Swup.umd.js"></script>
-    <script src="{{ site.baseurl }}/assets/lib/swup-head-plugin@2.2.0/index.umd.js"></script>
+    <script src="{{ site.baseurl }}/assets/lib/gsap@3.12.5/gsap.min.js?v=JS_BUST"></script>
+    <script src="{{ site.baseurl }}/assets/lib/swup@4.7.0/Swup.umd.js?v=JS_BUST"></script>
+    <script src="{{ site.baseurl }}/assets/lib/swup-head-plugin@2.2.0/index.umd.js?v=JS_BUST"></script>
     {% include custom-css.html %}
   </head>
   <body class="bg-white font-sans font-normal">


### PR DESCRIPTION
Added browser cache-busting to the new S3 deployment workflow to replace the cache-busting present in the old EC2 deployment workflow.

The new cache-busting hash value is ephemeral and is only present in the deployed files, which will reduce the number of commits as compared to the old cache-busting method.

A check step has been added to the new deploy to verify that the hash value has been added to the files.