### PR TITLE
Update PRM posting with new HR link

### DIFF
--- a/app/_jobs/product-and-research-manager.md
+++ b/app/_jobs/product-and-research-manager.md
@@ -5,6 +5,6 @@ order: 1
 ---
 At LIL, Product and Research Managers are the backbone of a varied and wide reaching product process that manages not only consumer-level design and software development, but also technology experimentation and the convening of in-person and virtual events. The ideal candidate is highly organized and goal oriented, thrives in cross-functional collaboration, and is able to quickly develop a strong perspective on the task at hand while remaining flexible to the road ultimately taken.
 
-For more information and to apply, fill out an [application form](https://careers.harvard.edu/job/product-and-research-manager-in-cambridge-ma-united-states-jid-317){: .interactive-link.dark.reverse} on Harvard’s career portal.
+To learn more about this role and apply, visit [Harvard's Careers Portal](https://us.smrtr.io/44g4J){: .interactive-link.dark.reverse}.
 
 In addition to Harvard’s standard application form, please provide a short cover letter explaining how your career trajectory and interests align with our work and mission.


### PR DESCRIPTION
We took the public listing off of Harvard Careers but if people find the job via visiting our website they can still apply.