### PR TITLE
Add Updates section to project page layout

### DIFF
--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -50,7 +50,7 @@ layout: default
             <span class="label col-span-3">
               <span class="align-middle">{{ post.date | date: "%m/%d/%y" }}</span>
             </span>
-            <span class="col-span-6">{% include arrow-link-inline.html label=post.title href=post.url target="_blank"%}</span>
+            <span class="col-span-6">{% include arrow-link-inline.html label=post.title href=post.url %}</span>
           </div>
         {% endfor %}
       </div>

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -40,6 +40,24 @@ layout: default
     {% include project-hero.html %}
   {% endif %}
 
+  {% assign updates = site.posts | where: "project", page.slug | slice: 0, 5 | sort: "date" | reverse %}
+  {% if updates.size > 0 %}
+    <section class="container flex flex-col items-start gap-12">
+      <h2 class="h2">Updates</h2>
+      <div class="flex flex-col items-start w-full">
+        {% for post in updates %}
+          <div class="body-text w-full py-24 md:py-36 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
+            <!-- format date as 02.12.24 -->
+            <span class="label col-span-3">
+              <span class="align-middle">{{ post.date | date: "%m/%d/%y" }}</span>
+            </span>
+            <span class="col-span-6">{% include arrow-link-inline.html label=post.title href=post.url target="_blank"%}</span>
+          </div>
+        {% endfor %}
+      </div>
+    </section>
+  {% endif %}
+
   {% assign news = site.data.news | where: "project", page.slug | sort: "date" | reverse %}
   {% if news.size > 0 %}
     <section class="container flex flex-col items-start gap-12">

--- a/app/_layouts/project.html
+++ b/app/_layouts/project.html
@@ -47,7 +47,6 @@ layout: default
       <div class="flex flex-col items-start w-full">
         {% for post in updates %}
           <div class="body-text w-full py-24 md:py-36 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
-            <!-- format date as 02.12.24 -->
             <span class="label col-span-3">
               <span class="align-middle">{{ post.date | date: "%m/%d/%y" }}</span>
             </span>
@@ -65,7 +64,6 @@ layout: default
       <div class="flex flex-col items-start w-full">
         {% for article in news %}
           <div class="body-text w-full py-24 md:py-36 {% unless forloop.first %}border-t-1{% endunless %} flex grid grid-cols-12 gap-24 relative">
-            <!-- format date as 02.12.24 -->
             <span class="label col-span-3">
               <span class="align-middle">{{ article.date | date: "%m/%d/%y" }}</span>
             </span>

--- a/app/_posts/2025-01-30-preserving-public-u-s-federal-data.md
+++ b/app/_posts/2025-01-30-preserving-public-u-s-federal-data.md
@@ -1,6 +1,7 @@
 ---
 title: Preserving Public U.S. Federal Data
 guest-author: Library Innovation Lab Team
+project: public-data-project
 ---
 ![](https://lil-blog-media.s3.amazonaws.com/Screenshot_2025-01-30_at_4.06.13_PM.png)
 

--- a/app/_posts/2025-02-06-announcing-data-gov-archive.md
+++ b/app/_posts/2025-02-06-announcing-data-gov-archive.md
@@ -1,6 +1,7 @@
 ---
 title: Announcing the Data.gov Archive
 guest-author: Library Innovation Lab Team
+project: public-data-project
 ---
 ![](https://lil-blog-media.s3.amazonaws.com/Blog_datagovarchive.jpg)
 


### PR DESCRIPTION
This adds an optional Updates section to the project page layout. The new section lists up to 5 blog posts, ordered from most recent, that are associated with the project by way of a `project` attribute in their front matter.

It adds an association between two blog posts and the Public Data Project so they now appear on its Our Work page like so:

<img width="3456" height="1575" alt="image" src="https://github.com/user-attachments/assets/da7973f2-8183-420e-adad-506d967c42ed" />