### PR TITLE
Add Swup handler for Generational Data Interviews page

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -393,6 +393,20 @@ function setupSwup() {
 
     // Register handler to hide marquee if user navigates away from homepage
     swup.hooks.on('content:replace', lilMarqueeHandler);
+
+    // Register handler to load interviews on Generational Data Interviews page
+    swup.hooks.on('content:replace', () => {
+        const isInterviewsLandingPage = window.location.pathname === '/generational-data-interviews/' || window.location.pathname === '/generational-data-interviews';
+        if (isInterviewsLandingPage) {
+            const script = document.querySelector('script[src*="generational-data-interviews"]');
+            if (!window.interviewsLoaded) {
+                const newScript = document.createElement('script');
+                newScript.src = script.src;
+                document.head.appendChild(newScript);
+                window.interviewsLoaded = true;
+            }
+        }
+    });
 }
 
 const setup = () => {

--- a/app/generational-data-interviews/main.js
+++ b/app/generational-data-interviews/main.js
@@ -87,6 +87,7 @@ function initInterviewSeries() {
             cleanupDropdownEventListeners();
             setupCentralizedDropdownManagement(); // Re-setup after cleanup
             loadInterviewees();
+            window.interviewsLoaded = true;
             // Add a small delay to ensure DOM is ready
             setTimeout(() => {
                 loadQuoteCards();


### PR DESCRIPTION
Before:
* Swup was preventing the `script` tag from being loaded on `generational-data-interviews/index.html` 

After:
* Swup handler ensures `script` tag gets loaded, but only once