### PR TITLE
Update Gemfile.lock to avoid extraneous build step

### DIFF
--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -71,4 +71,4 @@ DEPENDENCIES
   jekyll-sitemap
 
 BUNDLED WITH
-   2.0.2
+   2.4.6


### PR DESCRIPTION
Our build process always has to install a different version of Bundler in order to match Gemfile.lock:

```
Bundler 2.4.6 is running, but your lockfile was generated with 2.0.2. Installing Bundler 2.0.2 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.0.2
Installing bundler 2.0.2
```

I've re-generated the lockfile on this branch with Bundler 2.4.6 so we can skip this step.