### PR TITLE
Fix RSS and Atom feed URLs

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -13,7 +13,8 @@
     <link rel="apple-touch-icon" href="{{ site.baseurl }}/assets/images/apple-touch-favicon.png">
     <link rel="manifest" href="{{ site.baseurl }}/manifest.webmanifest">
     <link rel="stylesheet" href="{{ site.baseurl }}/assets/css/main.css?v=CSS_BUST">
-    <link rel="alternate" href="{{ site.baseurl }}/blog/feed/" type="application/rss+xml" title="RSS Feed">
+    <link rel="alternate" href="{{ site.baseurl }}/blog/feed/index.xml" type="application/rss+xml" title="RSS Feed">
+    <link rel="alternate" href="{{ site.baseurl }}/blog/feed/atom/index.xml" type="application/atom+xml" title="Atom Feed">
     <script src="{{ site.baseurl }}/assets/lib/gsap@3.12.5/gsap.min.js?v=JS_BUST"></script>
     <script src="{{ site.baseurl }}/assets/lib/swup@4.7.0/Swup.umd.js?v=JS_BUST"></script>
     <script src="{{ site.baseurl }}/assets/lib/swup-head-plugin@2.2.0/index.umd.js?v=JS_BUST"></script>


### PR DESCRIPTION
At some point during the past year, our production RSS and Atom feed URL(s) appear to have stopped working. This might be an issue of a missing redirect, since the `index.xml` feed files themselves still look good.

In any event, this updates the RSS `link` element in the layout header so it points to the complete working URL: `/blog/feed/index.xml`. I also added another `link` pointing to the Atom feed so RSS readers have the option of either.