### PR TITLE
Add Public Data featured tag to LIL blog

### DIFF
--- a/app/_data/featured_tags.yaml
+++ b/app/_data/featured_tags.yaml
@@ -1,4 +1,5 @@
 - AI Research
-- Tools
-- Library Principles
 - Fellows’ Research
+- Library Principles
+- Public Data
+- Tools

--- a/app/_posts/2025/2025-01-30-preserving-public-u-s-federal-data.md
+++ b/app/_posts/2025/2025-01-30-preserving-public-u-s-federal-data.md
@@ -2,6 +2,8 @@
 title: Preserving Public U.S. Federal Data
 guest-author: Library Innovation Lab Team
 project: public-data-project
+tags:
+  - Public Data
 ---
 ![](https://lil-blog-media.s3.amazonaws.com/Screenshot_2025-01-30_at_4.06.13_PM.png)
 

--- a/app/_posts/2025/2025-02-06-announcing-data-gov-archive.md
+++ b/app/_posts/2025/2025-02-06-announcing-data-gov-archive.md
@@ -2,6 +2,8 @@
 title: Announcing the Data.gov Archive
 guest-author: Library Innovation Lab Team
 project: public-data-project
+tags:
+  - Public Data
 ---
 ![](https://lil-blog-media.s3.amazonaws.com/Blog_datagovarchive.jpg)
 

--- a/app/_posts/2025/2025-09-18-expanding-our-public-data-project-to-include-smithsonian-collections-data.md
+++ b/app/_posts/2025/2025-09-18-expanding-our-public-data-project-to-include-smithsonian-collections-data.md
@@ -4,6 +4,8 @@ author:
 date: 2025-09-18T12:00:00-04:00
 title: Expanding Our Public Data Project to Include Smithsonian Collections Data
 project: public-data-project
+tags:
+  - Public Data
 ---
 <figure class="items-center text-center">
   <img class="h-fit w-full !mb-0" src="https://lil-blog-media.s3.amazonaws.com/smithsonian-building-sunlight.jpg" alt="Photograph of the Smithsonian Institution Building in Washington, D.C." />

--- a/app/_posts/2025/2025-10-10-welcome-to-lil-s-data-gov-archive-search.md
+++ b/app/_posts/2025/2025-10-10-welcome-to-lil-s-data-gov-archive-search.md
@@ -5,6 +5,8 @@ author:
 date: 2025-10-10T16:00:00-04:00
 title: Welcome to LIL’s Data.gov Archive Search
 project: public-data-project
+tags:
+  - Public Data
 ---
 <figure class="items-center text-center">
   <img class="h-fit w-full !mb-0" src="https://lil-blog-media.s3.amazonaws.com/card_division_of_the_library_of_congress.jpg" alt="Photograph of people working in the Card Division of the Library of Congress, circa 1900–1920" />

--- a/app/_posts/2025/2025-10-24-rethinking-data-discovery-for-libraries-and-digital-humanities.md
+++ b/app/_posts/2025/2025-10-24-rethinking-data-discovery-for-libraries-and-digital-humanities.md
@@ -5,6 +5,8 @@ author:
 date: 2025-10-24T16:00:00-04:00
 title: Rethinking Data Discovery for Libraries and Digital Humanities
 project: public-data-project
+tags:
+  - Public Data
 ---
 <figure class="items-center text-center">
   <img class="h-fit w-full" src="https://lil-blog-media.s3.amazonaws.com/macey_vertical_filing_cabinet_1903.jpg" alt="Illustration of a woman using a Macey vertical filing cabinet, from a 1903 catalogue" />


### PR DESCRIPTION
There's been a request to add Public Data to the list of featured tags on the LIL blog. This branch adds the tag, and also reorders the other featured tags so they're arranged alphabetically.