### PR TITLE
Remove "Featured" tag from Perma

### DIFF
--- a/app/_our_work/perma-cc.md
+++ b/app/_our_work/perma-cc.md
@@ -4,7 +4,7 @@ order: 1
 retired: false
 retired_date:
 layout: project
-featured: true
+featured:
 
 ### PROJECT METADATA ###
 # Required


### PR DESCRIPTION
We've added the Public Data Project as the "Featured Project" on the LIL homepage:

<img width="1069" height="621" alt="Screenshot 2026-01-15 at 9 45 35 AM" src="https://github.com/user-attachments/assets/5a2727b9-410e-4220-8f6a-f0e56c73937d" />

We shouldn't have double! So, I removed Perma's "featured" tag. 