### PR TITLE
Un-list User Support Coordinator job 

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -1,7 +1,7 @@
 <lil-header class="block relative z-header">
-  {% if page.slug == "home" %}
+   <!-- {% if page.slug == "home" %}
     {% include hiring-banner.html title="User Support Coordinator" %}
-  {% endif %}
+  {% endif %} -->
   <header class="pt-24 md:pt-36 nav-container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>

--- a/app/_jobs/user-support-coordinator.md
+++ b/app/_jobs/user-support-coordinator.md
@@ -2,6 +2,7 @@
 title: User Support Coordinator
 category: staff
 order: 1
+published: false
 ---
 We are hiring a User Support Coordinator to help us build tools and communities for open knowledge. This role acts as the front door to our lab, triaging and handling incoming messages from the users of our various projects. They also are teachers, developing and executing trainings on a range of topics related to our work.
 


### PR DESCRIPTION
We have stopped accepting new applications for this role, so this PR would un-publish the listing. I did not fully delete it yet, simply because we haven't finished the hiring process. 