### PR TITLE
Accessibility fixes

### DIFF
--- a/app/_includes/project-card.html
+++ b/app/_includes/project-card.html
@@ -9,7 +9,7 @@
       <img class="w-full max-w-[132px] min-h-[132px] max-h-[132px] pb-12 tbl:max-w-[348px] tbl:max-h-[300px] tbl:pb-0 object-contain object-left tbl:object-center" src="/assets/images/{{ logo }}" alt="{{ title }}">
     </div>
     <div class="w-full p-24 pt-0 tbl:p-72 flex flex-col gap-18 tbl:gap-32">
-      <strong class="h2">{{ title }}</strong>
+      <h2 class="h2">{{ title }}</h2>
       <p class="body-text">{{ description }}</p>
       <div class="flex flex-col tbl:flex-row tbl:items-center gap-18 tbl:gap-32 pt-12 tbl:pt-24 whitespace-nowrap">
         {% if linkOne %}

--- a/app/_includes/sharing-image.html
+++ b/app/_includes/sharing-image.html
@@ -41,9 +41,18 @@
 <meta name="twitter:title" content="{{ sharing-title | strip | escape_once }}">
 <meta name="twitter:description" content="{{ sharing-description | strip | escape_once}}">
 <meta name="twitter:image" content="{{ site.url }}/assets/{{ sharing-image | strip }}">
+<meta name="twitter:image:alt" content="{{ sharing-title | strip | escape_once }}">
 
 <meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ site.title }}">
 <meta property="og:url" content="{{ site.url }}{{ page.url | replace:'index.html',''}}">
 <meta property="og:title" content="{{ sharing-title | strip | escape_once }}">
 <meta property="og:description" content="{{ sharing-description | strip | escape_once }}">
 <meta property="og:image" content="{{ site.url }}/assets/{{ sharing-image | strip }}">
+{% if sharing-card-type == "summary_large_image" %}
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+{% else %}
+<meta property="og:image:width" content="800">
+<meta property="og:image:height" content="800">
+{% endif %}

--- a/app/_posts/2013/2013-02-28-hiring-a-developer-to-chart-the-future-of-libraries.md
+++ b/app/_posts/2013/2013-02-28-hiring-a-developer-to-chart-the-future-of-libraries.md
@@ -28,7 +28,9 @@ The best way to get a feel for what we do is by looking at [our projects]({{ sit
 
 StackLife, our soon-to-launch Library Browser
 
-![LABRARY](https://lil-blog-media.s3.amazonaws.com/2013/02/LABRARY.gif)
+<video controls loop preload="metadata" aria-label="LABRARY">
+  <source src="https://lil-blog-media.s3.amazonaws.com/2013/02/LABRARY.webm" type="video/webm">
+</video>
 
 [Library Test Kitchen](http://librarytestkitchen.org) is a course we run in the Fall, in it we launched LABRARY, a Pop-Up Library Experiment
 

--- a/app/_posts/2016/2016-12-22-physical-pitch-decks.md
+++ b/app/_posts/2016/2016-12-22-physical-pitch-decks.md
@@ -9,7 +9,9 @@ I've been playing with physical pitch decks lately. Slides as printed cards.
 
 PowerPoint, [Deck.js](http://imakewebthings.com/deck.js/), and the like are fantastic when sharing with large groups of people — from a classroom full of folks to a web full of folks. But, what if easy and broad sharing isn't a criteria for your pitch deck?
 
-![](https://lil-blog-media.s3.amazonaws.com/2016/12/pitch-med.gif)
+<video controls loop preload="metadata" aria-label="Video of physical pitch deck cards">
+  <source src="https://lil-blog-media.s3.amazonaws.com/2016/12/pitch-med.webm" type="video/webm">
+</video>
 
 You might end up with physical cards like I did when I recently pitched [Private Talking Spaces]({{ site.url }}/blog/2016/09/02/private-talking-spaces-progress/). The cards are surprisingly good!! Just like non-physical slides, they can provide outlines for talks and discussions, but they're so simple (just paper and ink), they won't get in the way when sharing ideas with small groups.
 

--- a/app/_posts/2017/2017-04-17-lil-talks-parsing-caselaw.md
+++ b/app/_posts/2017/2017-04-17-lil-talks-parsing-caselaw.md
@@ -18,7 +18,9 @@ In last week’s LIL talk, expert witness Adam Ziegler took the stand to explain
 
 First on the docket was a general overview of our country’s judicial structure, specifically noting the similarities between our federal and state systems, which both progress from district courts, to appellate courts, to supreme courts.
 
-![](https://lil-blog-media.s3.amazonaws.com/2_adamated_gif.gif)
+<video controls loop preload="metadata" aria-label="Adam Ziegler's presentation">
+  <source src="https://lil-blog-media.s3.amazonaws.com/2_adamated_gif.webm" type="video/webm">
+</video>
 
 Next, we dissected several cases which would eventually be heard by the US Supreme Court. While some elements, such as a list of attorneys and the opinion text, are standard in all cases, each court individually decides how their cases will be formatted. They are, however, often forced to work within the guidelines and workflows specified by their contracted publishers.
 

--- a/app/_posts/2017/2017-05-18-lil-talks-a-small-study-of-epic-proportions.md
+++ b/app/_posts/2017/2017-05-18-lil-talks-a-small-study-of-epic-proportions.md
@@ -27,6 +27,8 @@ The presentation dealt with four analytical methodologies applied in the thesis.
 
 \4. _Network Analysis_. By leveraging statistical tools to analyze the coincidence of and interactions between the Aeneid’s many characters, Yunhan generated a number of compelling visualizations mapping narrative progression between books in terms of relationships.
 
-![](https://lil-blog-media.s3.amazonaws.com/big.gif)
+<video controls loop preload="metadata" aria-label="Yunhan Xu's presentation">
+  <source src="https://lil-blog-media.s3.amazonaws.com/big.webm" type="video/webm">
+</video>
 
 In the closing minutes of her presentation, Yunhan reflected on the broader implications of the digital humanities for the study of classics. While some scholars remain skeptical of the digital humanities, Yunhan sees enormous potential for collaboration and coevolution between the new way and the old.

--- a/app/_posts/2017/2017-05-19-2761.md
+++ b/app/_posts/2017/2017-05-19-2761.md
@@ -20,7 +20,9 @@ We tasted
 *  Gerolsteiner – Minerally with low carbonation
 *  Borjomi – Graphite, very minerally, small bubbles, funk
 
-![](https://lil-blog-media.s3.amazonaws.com/matt_seltzer.gif)
+<video controls loop preload="metadata" aria-label="Matt's seltzer presentation">
+  <source src="https://lil-blog-media.s3.amazonaws.com/matt_seltzer.webm" type="video/webm">
+</video>
 
 Of course, throughout the conversation, we discussed the potential for the bottles affecting our opinions. We agreed that for a truly objective comparison, we’d transfer the samples to generic containers.
 

--- a/app/_posts/2017/2017-07-10-lil-talks-comedy.md
+++ b/app/_posts/2017/2017-07-10-lil-talks-comedy.md
@@ -23,6 +23,8 @@ As one example, Brett showed and broke down multiple jokes into the core structu
 
 We also explored what it meant to be a comic, and how the immediacy of audience reaction and enjoyment means that stand up comedy is one of the only art forms with an extremely evident (and sometimes, brutal) line between success and failure.
 
-![](https://lil-blog-media.s3.amazonaws.com/Burst_Cover_GIF_Action_20170707141317_sm.gif)
+<video controls loop preload="metadata" aria-label="Brett Johnson's presentation">
+  <source src="https://lil-blog-media.s3.amazonaws.com/Burst_Cover_GIF_Action_20170707141317_sm.webm" type="video/webm">
+</video>
 
 Though the talk was littered with choice jokes and funny bits, we definitely came away with a refreshing look into some aspects of stand-up comedy that rarely goes noticed.

--- a/app/_posts/2017/2017-08-10-git-physical.md
+++ b/app/_posts/2017/2017-08-10-git-physical.md
@@ -16,7 +16,9 @@ Last week at LIL, I had the pleasure of running a pilot of **git physical**, the
 
 The participants, a diverse group of fellows and interns, engaged in a simplified version control exercise. Each participant was tasked with designing a postcard about their summer at LIL. Following basic git workflow, they took their designs from the working directory, through the staging index, to the version database, and to the remote repository where they displayed them. In the process they “pushed” five versions of their postcard design, each accompanied by a commit note. Working in this way allowed them to experience the workflow in a familiar setting and learn the basics in an interactive and social environment. By the end of the workshop everyone had ideas on how to implement git in their work and was eager to learn more.
 
-![](https://lil-blog-media.s3.amazonaws.com/s1-smaller-copy.gif)
+<video controls loop preload="metadata" aria-label="Timelapse of git physical workshop">
+  <source src="https://lil-blog-media.s3.amazonaws.com/s1-smaller-copy.webm" type="video/webm">
+</video>
 
 Timelapse gif by Doyung Lee ([doyunglee.github.io](http://doyunglee.github.com/))
 

--- a/app/_posts/2021/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
+++ b/app/_posts/2021/2021-11-10-interface-upgrade-integrating-queries-into-search-and-case-view.md
@@ -7,11 +7,15 @@ tags:
 ---
 With expanded feature capabilities, users may find writing these queries to be more difficult, especially as researchers increase the complexity of their investigations. To make usage easier, we have integrated the [Trends](https://case.law/trends/) query language into the [Search](https://case.law/search/) and [Case View](https://cite.case.law/) features. From a search query, users can click the Trends button, upon which our servers will automatically convert an existing query into a Trends timeline.
 
-![Gif showing search results converted into a Trend timeline.](https://lil-blog-media.s3.amazonaws.com/Post3Figure1.gif)
+<video controls loop preload="metadata" aria-label="Video showing search results converted into a Trend timeline">
+  <source src="https://lil-blog-media.s3.amazonaws.com/Post3Figure1.webm" type="video/webm">
+</video>
 
 Additionally, users can now view the citation history of a particular case from that case's page by clicking the "View citation history in trends" button.
 
-![Gif showing ability to display citation history on a Trend timeline from an individual case](https://lil-blog-media.s3.amazonaws.com/Post3Figure2.gif)
+<video controls loop preload="metadata" aria-label="Video showing ability to display citation history on a Trend timeline from an individual case">
+  <source src="https://lil-blog-media.s3.amazonaws.com/Post3Figure2.webm" type="video/webm">
+</video>
 
 Our exploration of timeline generation for empirical legal scholarship has inspired us to reimagine how people reason about CAP's corpus of American caselaw. In the future, we hope to restructure the search page further and empower people to quickly ask complex questions about American caselaw over time.
 

--- a/app/about/index.html
+++ b/app/about/index.html
@@ -25,11 +25,11 @@ layout: default
     </div>
   </section>
 
-  <section>
+  <section aria-label="Photo of the Reginald F. Lewis Center at Harvard University">
     <figure>
       <picture>
         <img src="/assets/images/lewis-center-web.jpg"
-            alt=""
+            alt="Photo of the Reginald F. Lewis Center at Harvard University"
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
       <figcaption class="block container text-16 py-8">

--- a/app/assets/css/post-content.css
+++ b/app/assets/css/post-content.css
@@ -38,6 +38,13 @@
   margin-bottom: 40px;
 }
 
+.post-content video {
+  margin-top: 20px;
+  margin-bottom: 40px;
+  max-width: 100%;
+  height: auto;
+}
+
 .post-content figure > img {
   margin: 0;
 }

--- a/app/events.html
+++ b/app/events.html
@@ -15,7 +15,7 @@ layout: default
   {% assign next_event = collections.events | where_exp: 'item','item.date >= now' | sort: 'date' | first %}
   {% if next_event %}
     {% if next_event.data.banner %}
-      <section class="container mb-30 tbl:mb-60">
+      <section aria-label="Event banner" class="container mb-30 tbl:mb-60">
         <div class="w-full relative">
           <figure>
             <picture>
@@ -25,7 +25,7 @@ layout: default
               {% endif %}
               <source srcset="/assets/images/events/{{ next_event.data.banner }}">
               <img src="/assets/images/events/{{ next_event.data.banner }}"
-                  alt=""
+                  alt="Banner for {{ next_event.data.title }}"
                   class="img-full-width">
             </picture>
           </figure>
@@ -37,7 +37,7 @@ layout: default
         <div class="flex flex-col items-start gap-12">
           <div class="label">Next Event</div>
           <div class="flex flex-col md:grid md:grid-cols-3 md:gap-36 pb-36 md:pb-48 items-baseline">
-            <h1 class="h2">{{ next_event.data.title }}–{{ next_event.data.date_informal }}</h1>
+            <h2 class="h2">{{ next_event.data.title }}–{{ next_event.data.date_informal }}</h2>
             <div class="md:col-span-2 body-text md:max-w-[700px] flex flex-col items-start gap-20">
               {{ next_event.data.excerpt }}
             {% capture linkLabel %}

--- a/app/jobs/index.html
+++ b/app/jobs/index.html
@@ -14,11 +14,11 @@ layout: default
 </section>
 
 <div class="flex flex-col gap-50 md:gap-80">
-  <section>
+  <section aria-label="Photo of the Reginald F. Lewis Center at Harvard University">
     <figure>
       <picture>
         <img src="/assets/images/lewis-center-careers.jpg"
-            alt=""
+            alt="Photo of the Reginald F. Lewis Center at Harvard University"
             class="img-full-width aspect-[1/.45] object-cover overflow-hidden">
       </picture>
       <figcaption class="block container text-16 py-8">

--- a/app/open-french-law-rag/index.html
+++ b/app/open-french-law-rag/index.html
@@ -53,7 +53,7 @@
       </nav>
 
       <div class="content">
-        <section id="authors" class="fade-in">
+        <section id="authors" class="fade-in" aria-label="Authors">
           <div class="author">
             <img src="https://lil-blog-media.s3.amazonaws.com/kristi-mukk.jpg" alt="Kristi Mukk"/>
             <a href="https://lil.law.harvard.edu/about/#kristi-mukk">Kristi Mukk</a>

--- a/app/our-work.html
+++ b/app/our-work.html
@@ -72,7 +72,7 @@ layout: default
     </div>
   </section>
 
-  <section class="flex flex-col gap-12 pb-12 tbl:gap-24 tbl:pb-24">
+  <section aria-label="Projects" class="flex flex-col gap-12 pb-12 tbl:gap-24 tbl:pb-24">
     {% assign active_platforms = collections.our_work | where:"category","platforms" | where:"retired",false | sort: "order" %}
     {% for platform in active_platforms %}
       {% capture linkOneLabel %}


### PR DESCRIPTION
This resolves the remaining issues https://github.com/harvard-lil/website-static/issues/34, https://github.com/harvard-lil/website-static/issues/347, and https://github.com/harvard-lil/website-static/issues/353:

* Added missing headings and/or `aria-label`s for `section` elements
* Converted old animated GIFs in blog posts (9 total) to webm videos so they can be stopped/started
* Added `meta` tags to help display header images when a page/post is shared on Slack or other apps