### PR TITLE
Update Old News, New Evidence event

### DIFF
--- a/app/_events/old-news-new-evidence.md
+++ b/app/_events/old-news-new-evidence.md
@@ -9,10 +9,12 @@ banner: old-news-new-evidence-banner-sm.png
 banner_large: old-news-new-evidence-banner-lg.png
 ---
 
+**Click to join the event on Zoom: [bsy.sh/4PdAt6i](https://bsy.sh/4PdAt6i)**
+
 Please join Harvard Law School Library researchers to explore the history of newspapers and their uses in legal research. Starting with an overview of newspapers as disseminators of the law and as shapers of the nation, they will then offer examples and cautionary tales about how "the first drafts of history" have been used to provide evidence, uncover buried histories, and offer windows into the past. Their presentation will cover strategies for using historical newspapers in the digital age, highlighting obstacles and showcasing resources.
 
 **Shay Elbaum** is a Faculty Research Librarian at the Harvard Law School Library, where he does a little bit of everything but focuses on supporting law school faculty with their scholarly research. He is working on an article about historical newspapers as neglected sources of legislative history.
 
 **Molly Hardy** currently serves as the Project Lead for the [Public Data Project](/our-work/public-data-project/) at Harvard Law School's Library Innovation Lab. Previously, as a senior program officer at the National Endowment for the Humanities, she managed _Chronicling America_, a collaboration with the Library of Congress and libraries throughout the country. Her most recent article, "Newspapers and Memory," can be found in the _Cambridge History of the American Revolution_ (2026).
 
-**This event is jointly hosted by Harvard Law School Library Innovation Lab and the Association of Boston Law Libraries.**
+**This event is jointly hosted by Harvard Law School Library Innovation Lab and the Association of Boston Law Librarians.**


### PR DESCRIPTION
Per request, this adds a Zoom link to the May 21 event page. I also fixed a typo in the name of the ABLL.