### PR TITLE
Fix inconsistency in display of hiring banner

### DIFF
--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -1,7 +1,7 @@
 <lil-header class="block relative z-header">
-   {% if slug == "home" %}
-      {% include "hiring-banner.html", title: "Perma.cc Legal Digital Scholarship Project Manager" %}
-  {% endif %}
+  {% assign isHome = false %}
+  {% if slug == "home" %}{% assign isHome = true %}{% endif %}
+  {% include "hiring-banner.html", title: "Perma.cc Legal Digital Scholarship Project Manager", isHome: isHome %}
   <header class="pt-24 md:pt-36 nav-container">
     <div class="flex items-center justify-between">
       <div aria-hidden class="opacity-0 w-[40px] md:w-[56px]"></div>

--- a/app/_includes/hiring-banner.html
+++ b/app/_includes/hiring-banner.html
@@ -1,5 +1,5 @@
 {% if title.size > 0 %}
-<lil-marquee class="block marquee bg-purple py-6 md:py-10 px-20 uppercase font-mono text-14 md:text-16 leading-120 tracking-[0.02em] md:tracking-[0.07em] text-announcement whitespace-nowrap overflow-hidden relative z-[100]">
+<lil-marquee class="block marquee bg-purple py-6 md:py-10 px-20 uppercase font-mono text-14 md:text-16 leading-120 tracking-[0.02em] md:tracking-[0.07em] text-announcement whitespace-nowrap overflow-hidden relative z-[100]{% unless isHome %} hidden{% endunless %}">
   <a href="/jobs/" class="marquee__inner">
     <div class="marquee__part inline-block">* We're hiring — {{ title }} </div>
     {% for i in (1..4) %}


### PR DESCRIPTION
I noticed a minor UI bug with the display of the hiring banner. If you start at the home page `/`, the banner appears as expected. But if you start on another page (e.g. `/about`) and then navigate to the home page, the banner fails to render. (As with many other cryptic LIL website behaviors, this can be chalked up to the page-transition library Swup.)

Anyway, this branch should fix the issue.