### PR TITLE
Show Gizmodo post in Public Data Project updates

### DIFF
--- a/app/_data/news.yaml
+++ b/app/_data/news.yaml
@@ -301,3 +301,11 @@
     https://conversationalist.org/2026/04/10/guerrilla-archives-activism-protest-history-preservation-politics-marion-stokes-media/
   archived_url: https://perma.cc/XFE8-2U6G
   archived_date: 2025-04-21T00:00:00-04:00
+- project: public-data-project
+  type: press
+  title: Will We Ever Solve the Problem of Losing Data?
+  publication: Gizmodo
+  date: 2026-07-30T07:30:00-04:00
+  url: https://gizmodo.com/will-we-ever-solve-the-problem-of-losing-data-2000792386
+  archived_url: https://perma.cc/9K6W-3WAW
+  archived_date: 2026-08-04T13:05:12-04:00

--- a/app/_posts/2026/2026-08-04-will-we-ever-solve-the-problem-of-losing-data.md
+++ b/app/_posts/2026/2026-08-04-will-we-ever-solve-the-problem-of-losing-data.md
@@ -2,8 +2,11 @@
 title: Will We Ever Solve the Problem of Losing Data?
 author:
   - jack-cushman
+date: 2026-08-04T12:00:00-04:00
+project: public-data-project
 tags:
   - Library Principles
+  - Public Data
 ---
 For a recent installment of Gizmodo's Giz Asks series, Gayoung Lee asked researchers in computer science, cybersecurity, and libraries: [will we ever solve the problem of losing data?](https://gizmodo.com/will-we-ever-solve-the-problem-of-losing-data-2000792386)
 


### PR DESCRIPTION
Follow-up to #805: adds project/tag/date frontmatter so the post appears in Public Data Project updates and the Public Data tag page.