### PR TITLE
Speed up Eleventy builds

### DIFF
--- a/app/api/contributors-feeds.liquid
+++ b/app/api/contributors-feeds.liquid
@@ -6,4 +6,4 @@ pagination:
 permalink: "/api/contributors/{{ project.data.slug | default: project.fileSlug }}/index.js"
 eleventyExcludeFromCollections: true
 ---
-contributors({"contributors": [{% for name in project.data.who_contributed %}{% assign person = people[name] %}{{ person | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}], "image_base": "{{ site.url }}/assets/thumbs/216x216c", "date": "{{ 'now' | date: '%Y-%m-%d %H:%M:%S' }}"})
+contributors({"contributors": [{% for name in project.data.who_contributed %}{% assign person = people[name] %}{{ person | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}], "image_base": "{{ site.url }}/assets/thumbs/216x216c"})

--- a/app/api/news-feeds.liquid
+++ b/app/api/news-feeds.liquid
@@ -6,6 +6,7 @@ pagination:
 permalink: "/api/news/{{ project.data.slug | default: project.fileSlug }}/index.js"
 eleventyExcludeFromCollections: true
 ---
-{% assign project_slug = project.data.slug | default: project.fileSlug %}
-{% assign project_news = news | where: "project", project_slug %}
-news({"news": {{ project_news | jsonify }}, "date": "{{ 'now' | date: '%Y-%m-%d %H:%M:%S' }}"})
+{%- assign project_slug = project.data.slug | default: project.fileSlug -%}
+{%- assign project_news = news | where: "project", project_slug -%}
+{%- assign latest_news = project_news | latest_update -%}
+news({"news": {{ project_news | jsonify }}, "date": "{% if latest_news %}{{ latest_news | date: '%Y-%m-%d %H:%M:%S' }}{% endif %}"})

--- a/app/blog/category-pages.html
+++ b/app/blog/category-pages.html
@@ -30,11 +30,11 @@ eleventyExcludeFromCollections: true
 
     <div class="post-grids__default">
       <div class="container grid grid-cols-2 gap-x-2 gap-y-5 md:gap-y-6 md:gap-x-6 md:grid-cols-4">
-        {% assign last_random_number = nil %}
+        {% assign last_thumb_index = nil %}
         {% for post in catData.posts %}
-          {% assign random_number = 5 | random_number: last_random_number %}
-          {% include "post-card.html", post: post, thumb_index: random_number %}
-          {% assign last_random_number = random_number %}
+          {% assign thumb_index = 5 | hashed_number: post.url, last_thumb_index %}
+          {% include "post-card.html", post: post, thumb_index: thumb_index %}
+          {% assign last_thumb_index = thumb_index %}
         {% endfor %}
       </div>
 

--- a/app/blog/feed/atom/index.xml.liquid
+++ b/app/blog/feed/atom/index.xml.liquid
@@ -1,11 +1,12 @@
 ---
 permalink: /blog/feed/atom/index.xml
 ---
+{%- assign recent_posts = collections.posts | reverse | slice: 0, 10 -%}
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" {% if site.lang %}xml:lang="{{ site.lang }}"{% endif %}>
   <link href="{{ site.url }}{{ page.url | remove: 'index.xml' }}" rel="self" type="application/atom+xml" />
   <link href="{{ site.url }}/" rel="alternate" type="text/html" {% if site.lang %}hreflang="{{ site.lang }}" {% endif %}/>
-  <updated>{{ "now" | date_to_xmlschema }}</updated>
+  <updated>{{ recent_posts | latest_update | date_to_xmlschema }}</updated>
   <id>{{ site.url | append: "/" | xml_escape }}</id>
 
   {% if site.title %}
@@ -18,7 +19,6 @@ permalink: /blog/feed/atom/index.xml
     <subtitle>{{ site.description | xml_escape }}</subtitle>
   {% endif %}
 
-  {% assign recent_posts = collections.posts | reverse | slice: 0, 10 %}
   {% for post in recent_posts %}
     <entry{% if post.data.lang %}{{" "}}xml:lang="{{ post.data.lang }}"{% endif %}>
       <title type="html">{{ post.data.title | smartify | strip_html | normalize_whitespace | xml_escape }}</title>

--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -31,11 +31,11 @@ permalink: "/blog/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumbe
 
     <div class="post-grids__default">
       <div class="container grid grid-cols-2 gap-x-2 gap-y-5 md:gap-y-6 md:gap-x-6 md:grid-cols-4">
-        {% assign last_random_number = nil %}
+        {% assign last_thumb_index = nil %}
         {% for post in pagination.items %}
-          {% assign random_number = 5 | random_number: last_random_number %}
-          {% include "post-card.html", post: post, thumb_index: random_number %}
-          {% assign last_random_number = random_number %}
+          {% assign thumb_index = 5 | hashed_number: post.url, last_thumb_index %}
+          {% include "post-card.html", post: post, thumb_index: thumb_index %}
+          {% assign last_thumb_index = thumb_index %}
         {% endfor %}
       </div>
 

--- a/app/blog/tag-pages.html
+++ b/app/blog/tag-pages.html
@@ -30,11 +30,11 @@ eleventyExcludeFromCollections: true
 
     <div class="post-grids__default">
       <div class="container grid grid-cols-2 gap-x-2 gap-y-5 md:gap-y-6 md:gap-x-6 md:grid-cols-4">
-        {% assign last_random_number = nil %}
+        {% assign last_thumb_index = nil %}
         {% for post in tagData.posts %}
-          {% assign random_number = 5 | random_number: last_random_number %}
-          {% include "post-card.html", post: post, thumb_index: random_number %}
-          {% assign last_random_number = random_number %}
+          {% assign thumb_index = 5 | hashed_number: post.url, last_thumb_index %}
+          {% include "post-card.html", post: post, thumb_index: thumb_index %}
+          {% assign last_thumb_index = thumb_index %}
         {% endfor %}
       </div>
 

--- a/app/search.json.liquid
+++ b/app/search.json.liquid
@@ -6,9 +6,9 @@ permalink: /search.json
 
 {% capture json %}
 [
-  {% assign last_random_number = nil %}
+  {% assign last_thumb_index = nil %}
   {% for doc in collections.posts reversed %}
-    {% assign random_number = 5 | random_number: last_random_number %}
+    {% assign thumb_index = 5 | hashed_number: doc.url, last_thumb_index %}
 
     {% assign content_parts = doc.templateContent | split: '<img' %}
     {% assign first_img_src = '' %}
@@ -26,9 +26,9 @@ permalink: /search.json
       "date": {{ doc.date | date: "%B %-d, %Y" | jsonify }},
       "content": {{ doc.templateContent | strip_html | default: "" | jsonify }},
       "url": {{ doc.url | default: "" | jsonify }},
-      "image": {% if first_img_src != '' %}"{{ first_img_src }}"{% else %}{% if doc.data.thumbnail %}{{ doc.data.thumbnail | jsonify }}{% else %}"/assets/images/blog-thumbnail-{{ random_number }}.png"{% endif %}{% endif %}
+      "image": {% if first_img_src != '' %}"{{ first_img_src }}"{% else %}{% if doc.data.thumbnail %}{{ doc.data.thumbnail | jsonify }}{% else %}"/assets/images/blog-thumbnail-{{ thumb_index }}.png"{% endif %}{% endif %}
     }{% unless forloop.last %},{% endunless %}
-    {% assign last_random_number = random_number %}
+    {% assign last_thumb_index = thumb_index %}
   {% endfor %}
 ]
 {% endcapture %}

--- a/config/collections.js
+++ b/config/collections.js
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 
 import slugify from "@sindresorhus/slugify";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 
 const slugCache = new Map();
 
@@ -31,7 +31,7 @@ export default function (eleventyConfig) {
   );
 
   eleventyConfig.addCollection("research", (collectionApi) => {
-    const additional = yaml.load(
+    const additional = load(
       fs.readFileSync("app/_data/additional_research.yaml", "utf8")
     );
     return [

--- a/config/collections.js
+++ b/config/collections.js
@@ -3,6 +3,17 @@ import fs from "node:fs";
 import slugify from "@sindresorhus/slugify";
 import yaml from "js-yaml";
 
+const slugCache = new Map();
+
+function slug(str) {
+  let cached = slugCache.get(str);
+  if (cached === undefined) {
+    cached = slugify(str, { decamelize: false });
+    slugCache.set(str, cached);
+  }
+  return cached;
+}
+
 export default function (eleventyConfig) {
   eleventyConfig.addCollection("posts", (collectionApi) =>
     collectionApi
@@ -64,24 +75,26 @@ export default function (eleventyConfig) {
   eleventyConfig.addCollection("tagsList", (collectionApi) => {
     const PAGE_SIZE = 12;
     const blogPosts = collectionApi.getFilteredByTag("posts");
+
     const tagMap = new Map();
     blogPosts.forEach((post) => {
       (post.data.tags || []).forEach((tag) => {
         if (tag === "posts") return;
-        const slug = slugify(tag, { decamelize: false });
-        if (!tagMap.has(slug)) {
-          tagMap.set(slug, tag);
+        const tagSlug = slug(tag);
+        let entry = tagMap.get(tagSlug);
+        if (!entry) {
+          entry = { name: tag, posts: [] };
+          tagMap.set(tagSlug, entry);
+        }
+        if (entry.posts.at(-1) !== post) {
+          entry.posts.push(post);
         }
       });
     });
 
     const pages = [];
-    tagMap.forEach((tag, tagSlug) => {
-      const tagPosts = blogPosts
-        .filter((post) =>
-          (post.data.tags || []).some((t) => slugify(t, { decamelize: false }) === tagSlug)
-        )
-        .reverse();
+    tagMap.forEach(({ name: tag, posts }, tagSlug) => {
+      const tagPosts = [...posts].reverse();
 
       const totalPages = Math.max(1, Math.ceil(tagPosts.length / PAGE_SIZE));
 
@@ -115,20 +128,27 @@ export default function (eleventyConfig) {
     const allPosts = collectionApi.getFilteredByTag("posts");
 
     const catMap = new Map();
+    const postsByCategory = new Map();
     allPosts.forEach((post) => {
       (post.data.categories || []).forEach((cat) => {
-        const slug = slugify(cat, { decamelize: false });
-        if (!catMap.has(slug)) {
-          catMap.set(slug, cat);
+        const catSlug = slug(cat);
+        if (!catMap.has(catSlug)) {
+          catMap.set(catSlug, cat);
+        }
+        let bucket = postsByCategory.get(cat);
+        if (!bucket) {
+          bucket = [];
+          postsByCategory.set(cat, bucket);
+        }
+        if (bucket.at(-1) !== post) {
+          bucket.push(post);
         }
       });
     });
 
     const pages = [];
     catMap.forEach((cat, catSlug) => {
-      const catPosts = allPosts
-        .filter((p) => (p.data.categories || []).includes(cat))
-        .reverse();
+      const catPosts = [...postsByCategory.get(cat)].reverse();
 
       const totalPages = Math.max(1, Math.ceil(catPosts.length / PAGE_SIZE));
 

--- a/config/filters.js
+++ b/config/filters.js
@@ -90,13 +90,20 @@ export default function (eleventyConfig) {
     return String(str).startsWith(prefix);
   });
 
-  eleventyConfig.addFilter("random_number", (max, lastNumber) => {
+  eleventyConfig.addFilter("hashed_number", (max, seed, lastNumber) => {
     const m = parseInt(max, 10);
-    let n;
-    do {
-      n = Math.floor(Math.random() * m) + 1;
-    } while (n === parseInt(lastNumber, 10) && m > 1);
-    return n;
+    if (!(m > 0)) return 1;
+
+    let hash = 0x811c9dc5;
+    for (const char of String(seed ?? "")) {
+      hash ^= char.codePointAt(0);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+
+    const n = (hash % m) + 1;
+
+    // Don't repeat the last number
+    return n === parseInt(lastNumber, 10) && m > 1 ? (n % m) + 1 : n;
   });
 
   eleventyConfig.addFilter("is_even", (n) => parseInt(n, 10) % 2 === 0);

--- a/config/filters.js
+++ b/config/filters.js
@@ -106,6 +106,18 @@ export default function (eleventyConfig) {
     return n === parseInt(lastNumber, 10) && m > 1 ? (n % m) + 1 : n;
   });
 
+  eleventyConfig.addFilter("latest_update", (posts) => {
+    let latest = null;
+    for (const post of posts || []) {
+      const raw = post.data?.last_modified_at || post.date;
+      const date = raw instanceof Date ? raw : new Date(raw);
+      if (!Number.isNaN(date.valueOf()) && (!latest || date > latest)) {
+        latest = date;
+      }
+    }
+    return latest;
+  });
+
   eleventyConfig.addFilter("is_even", (n) => parseInt(n, 10) % 2 === 0);
 
   eleventyConfig.addFilter("to_handle", (url) => {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,5 @@
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
-import yaml from "js-yaml";
+import { load } from "js-yaml";
 
 import assets from "./config/assets.js";
 import filters from "./config/filters.js";
@@ -22,7 +22,7 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addDataExtension("yaml,yml", (contents) =>
-    yaml.load(contents),
+    load(contents),
   );
 
   eleventyConfig.addGlobalData("assets", assets);

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -9,6 +9,17 @@ import collections from "./config/collections.js";
 process.env.TZ = "UTC";
 
 export default function (eleventyConfig) {
+  // Cache Liquid templates to reduce build time
+  const liquidCache = new Map();
+  eleventyConfig.setLiquidOptions({
+    cache: {
+      read: (key) => liquidCache.get(key),
+      write: (key, value) => liquidCache.set(key, value),
+      remove: (key) => liquidCache.delete(key),
+    },
+  });
+  eleventyConfig.on("eleventy.beforeWatch", () => liquidCache.clear());
+
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addDataExtension("yaml,yml", (contents) =>
     yaml.load(contents),

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tailwindcss/cli": "^4.3.2",
         "concurrently": "^10.0.4",
         "gsap": "^3.15.0",
-        "js-yaml": "^4.3.0",
+        "js-yaml": "^5.2.3",
         "markdown-it": "^14.1.0",
         "swup": "^4.9.2",
         "tailwindcss": "^4.3.2"
@@ -173,6 +173,29 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy/node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@11ty/lodash-custom": {
@@ -1679,9 +1702,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1891,9 +1914,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
       "funding": [
         {
@@ -1910,7 +1933,7 @@
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/junk": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tailwindcss/cli": "^4.3.2",
     "concurrently": "^10.0.4",
     "gsap": "^3.15.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.3",
     "markdown-it": "^14.1.0",
     "swup": "^4.9.2",
     "tailwindcss": "^4.3.2"


### PR DESCRIPTION
This speeds up the Eleventy build process considerably. Rebuilding the whole site now takes ~1.8 seconds.

Changes:

* Stopped rebuilding contributors and news feeds unless it's necessary
* Adopted hashing instead of a random number generator to assign default blog post thumbnail images
* Simplified `updated` timestamp calculation for Atom feed
* Started caching slugified identifiers for tags/categories
* Started caching Liquid templates

I also upgraded js-yaml to address a security vulnerability newly flagged by npm.