### PR TITLE
Restore timestamp auto-conversion when loading YAML

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,5 +1,5 @@
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
-import { load } from "js-yaml";
+import { CORE_SCHEMA, load, timestampTag } from "js-yaml";
 
 import assets from "./config/assets.js";
 import filters from "./config/filters.js";
@@ -22,7 +22,7 @@ export default function (eleventyConfig) {
 
   eleventyConfig.addPlugin(syntaxHighlight);
   eleventyConfig.addDataExtension("yaml,yml", (contents) =>
-    load(contents),
+    load(contents, { schema: CORE_SCHEMA.withTags(timestampTag) }),
   );
 
   eleventyConfig.addGlobalData("assets", assets);


### PR DESCRIPTION
This fixes a sorting issue resulting from the js-yaml upgrade in https://github.com/harvard-lil/website-static/pull/809. The newer version of js-yaml no longer auto-converts timestamp strings to `Date` objects by default, causing unexpected sorting behavior in mixed collections like `updates`. This branch restores the auto-conversion behavior.